### PR TITLE
Enable building on Ubuntu 21.04

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Build-depends: debhelper (>= 9.0.0),
                nymea-dev-tools:native,
                pkg-config,
                qtbase5-dev,
-               qt5-default,
                libi2c-dev
 Standards-Version: 3.9.3
 


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
