### PR TITLE
Update plugin selection qmake arguments

### DIFF
--- a/nymea-plugins-modbus.pro
+++ b/nymea-plugins-modbus.pro
@@ -48,19 +48,21 @@ QMAKE_EXTRA_TARGETS += lrelease
 # For Qt-Creator's code model: Add CPATH to INCLUDEPATH explicitly
 INCLUDEPATH += $$(CPATH)
 
-# Verify if building only a selection of plugins
-contains(CONFIG, selection) {
-    # Check each plugin if the subdir exists
-    for(plugin, PLUGINS) {
-        contains(PLUGIN_DIRS, $${plugin}) {
-            SUBDIRS*= $${plugin}
-        } else {
-            error("Invalid plugin passed. There is no subdirectory with the name $${plugin}.")
-        }
-    }
-    message("Building plugin selection: $${SUBDIRS}")
-} else {
-    SUBDIRS *= $${PLUGIN_DIRS}
-    message("Building all plugins")
-}
+message("Usage: qmake [srcdir] [WITH_PLUGINS=\"...\"] [WITHOUT_PLUGINS=\"...\"]")
 
+isEmpty(WITH_PLUGINS) {
+    PLUGINS = $${PLUGIN_DIRS}
+} else {
+    PLUGINS = $${WITH_PLUGINS}
+}
+PLUGINS-=$${WITHOUT_PLUGINS}
+
+message("Building plugins:")
+for(plugin, PLUGINS) {
+    exists($${plugin}) {
+        SUBDIRS*= $${plugin}
+        message("- $${plugin}")
+    } else {
+        error("Invalid plugin \"$${plugin}\".")
+    }
+}


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

- [x] If you added a new plugin, should it be added to nymea-plugins-all or nymea-plugins-maker?
