### PR TITLE
Kostal: Fix state name for total returned energy

### DIFF
--- a/kostal/integrationpluginkostal.json
+++ b/kostal/integrationpluginkostal.json
@@ -189,7 +189,7 @@
                         {
                             "id": "902ce047-ef6b-4868-9f7c-61a2ebe61a5b",
                             "name": "totalEnergyProduced",
-                            "displayName": "AC energy",
+                            "displayName": "Total returned energy",
                             "type": "double",
                             "unit": "KiloWattHour",
                             "defaultValue": 0.00,

--- a/kostal/translations/51a2c7d5-084d-4474-a65a-e0447ab9ac45-de_DE.ts
+++ b/kostal/translations/51a2c7d5-084d-4474-a65a-e0447ab9ac45-de_DE.ts
@@ -19,7 +19,7 @@
         <translation>Die Netzwerkaddresse ist noch nicht bekannt. Bitte versuche es später erneut.</translation>
     </message>
     <message>
-        <location filename="../integrationpluginkostal.cpp" line="362"/>
+        <location filename="../integrationpluginkostal.cpp" line="364"/>
         <source>Could not initialize the communication with the inverter.</source>
         <translation>Die Kommunikation mit dem Wechselrichter konnte nicht initialisiert werden.</translation>
     </message>
@@ -27,45 +27,39 @@
 <context>
     <name>Kostal</name>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="68"/>
-        <source>AC energy</source>
-        <extracomment>The name of the StateType ({902ce047-ef6b-4868-9f7c-61a2ebe61a5b}) of ThingClass kostalMeter</extracomment>
-        <translation>AC Energie</translation>
-    </message>
-    <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="71"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="68"/>
         <source>Active power</source>
         <extracomment>The name of the StateType ({bd68fa44-2628-4e4e-ac9b-5f2cf563eb4d}) of ThingClass kostalInverter</extracomment>
         <translation>Aktive Leistung</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="74"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="71"/>
         <source>Battery critical</source>
         <extracomment>The name of the StateType ({897616db-e815-4cda-b890-13b37a94ad17}) of ThingClass kostalBattery</extracomment>
         <translation>Batterieladung kritisch</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="77"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="74"/>
         <source>Battery level</source>
         <extracomment>The name of the StateType ({a4b0c8c9-44f0-43e2-ab25-63fdc9772fb8}) of ThingClass kostalBattery</extracomment>
         <translation>Batterie Ladung</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="80"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="77"/>
         <source>Capacity</source>
         <extracomment>The name of the StateType ({98099dbd-3f66-43b3-8192-f2e3fdcd5d62}) of ThingClass kostalBattery</extracomment>
         <translation>Kapazität</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="83"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="80"/>
         <source>Charging state</source>
         <extracomment>The name of the StateType ({829173e8-7535-4aba-b403-d498ff68250e}) of ThingClass kostalBattery</extracomment>
         <translation>Ladestatus</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="86"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="89"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="92"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="83"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="86"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="89"/>
         <source>Connected</source>
         <extracomment>The name of the StateType ({4a5a5a38-b623-4024-b557-410a46ebc495}) of ThingClass kostalBattery
 ----------
@@ -75,14 +69,14 @@ The name of the StateType ({8d64954a-855d-44ea-8bc9-88a71ab47b6b}) of ThingClass
         <translation>Verbunden</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="95"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="92"/>
         <source>Current power</source>
         <extracomment>The name of the StateType ({992b0da8-e6bd-47ab-af60-be8802fc7ecf}) of ThingClass kostalMeter</extracomment>
         <translation>Aktuelle Leistung</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="98"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="101"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="95"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="98"/>
         <source>Current power phase A</source>
         <extracomment>The name of the StateType ({2b1250eb-4c22-4025-ba7c-c3e8f27af3dc}) of ThingClass kostalMeter
 ----------
@@ -90,8 +84,8 @@ The name of the StateType ({aed44263-d15e-46d6-b6a3-66005ceb53c9}) of ThingClass
         <translation>Leistung Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="104"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="107"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="101"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="104"/>
         <source>Current power phase B</source>
         <extracomment>The name of the StateType ({0c43d20d-843c-4edd-9955-dafab6caecf6}) of ThingClass kostalMeter
 ----------
@@ -99,8 +93,8 @@ The name of the StateType ({8d8cd634-00dd-46c8-b34b-bbff552d0121}) of ThingClass
         <translation>Leistung Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="110"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="113"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="107"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="110"/>
         <source>Current power phase C</source>
         <extracomment>The name of the StateType ({a1e46df0-43e5-42f0-846a-5d2f24808a67}) of ThingClass kostalMeter
 ----------
@@ -108,8 +102,8 @@ The name of the StateType ({95f1ad78-0cb1-44cf-87b2-03e28b115f00}) of ThingClass
         <translation>Leistung Phase C</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="116"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="119"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="113"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="116"/>
         <source>Frequency</source>
         <extracomment>The name of the StateType ({7c86ea72-505b-4924-80ef-3cf3ff31a380}) of ThingClass kostalMeter
 ----------
@@ -117,44 +111,44 @@ The name of the StateType ({634a4659-5c73-40e9-a77d-4f2e555d05bb}) of ThingClass
         <translation>Frequenz</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="122"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="119"/>
         <source>KOSTAL Battery</source>
         <extracomment>The name of the ThingClass ({d6dbdfe8-adbb-47d8-840d-9b787683fc69})</extracomment>
         <translation>KOSTAL Batterie</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="125"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="122"/>
         <source>KOSTAL Inverter</source>
         <extracomment>The name of the ThingClass ({7dc6db14-6f5a-4ac8-9684-4c6a526bd0de})</extracomment>
         <translation>KOSTAL Wechselrichter</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="128"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="125"/>
         <source>KOSTAL Meter</source>
         <extracomment>The name of the ThingClass ({61af1e07-6a59-4465-a563-3cbf4a9fcbc3})</extracomment>
         <translation>KOSTAL Zähler</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="131"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="128"/>
         <source>KOSTAL Solar Electric</source>
         <extracomment>The name of the vendor ({862d1ebf-cb78-4c55-89b2-819fddfd9acd})</extracomment>
         <translation>KOSTAL Solar Electric</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="134"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="131"/>
         <source>Kostal</source>
         <extracomment>The name of the plugin Kostal ({51a2c7d5-084d-4474-a65a-e0447ab9ac45})</extracomment>
         <translation>Kostal</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="137"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="134"/>
         <source>MAC address</source>
         <extracomment>The name of the ParamType (ThingClass: kostalInverter, Type: thing, ID: {906f6099-d0e1-4297-a2b3-f8ec4482c578})</extracomment>
         <translation>MAC Addresse</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="140"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="143"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="137"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="140"/>
         <source>Phase A current</source>
         <extracomment>The name of the StateType ({1681ee7d-5d22-4794-8cfe-febaa1ddf29f}) of ThingClass kostalMeter
 ----------
@@ -162,8 +156,8 @@ The name of the StateType ({567bb3c2-4a0c-4194-a86e-b8dc29815092}) of ThingClass
         <translation>Stromstärke Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="146"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="149"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="143"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="146"/>
         <source>Phase B current</source>
         <extracomment>The name of the StateType ({b54e7182-6cb2-4184-96c5-2324e8139b6e}) of ThingClass kostalMeter
 ----------
@@ -171,8 +165,8 @@ The name of the StateType ({84e9282a-b72b-4dbf-9e4b-99083e5539a5}) of ThingClass
         <translation>Stromstärke Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="152"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="155"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="149"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="152"/>
         <source>Phase C current</source>
         <extracomment>The name of the StateType ({546eeb76-b17f-4c51-a9fa-01e7403913cd}) of ThingClass kostalMeter
 ----------
@@ -180,50 +174,56 @@ The name of the StateType ({4f7c308f-2cb2-4327-8a68-77222f920e61}) of ThingClass
         <translation>Stromstärke Phase C</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="158"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="155"/>
         <source>Port</source>
         <extracomment>The name of the ParamType (ThingClass: kostalInverter, Type: thing, ID: {9d2175af-afb9-4b31-b3dc-e53a369bad9e})</extracomment>
         <translation>Port</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="161"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="158"/>
         <source>Slave ID</source>
         <extracomment>The name of the ParamType (ThingClass: kostalInverter, Type: thing, ID: {b3e04cb0-8f9a-4c9f-9c67-5c08da0273e3})</extracomment>
         <translation>Modbus ID</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="164"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="161"/>
         <source>Temperature</source>
         <extracomment>The name of the StateType ({47b07030-57eb-4c79-a469-87b2474eb312}) of ThingClass kostalBattery</extracomment>
         <translation>Temperatur</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="167"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="164"/>
         <source>Total energy produced</source>
         <extracomment>The name of the StateType ({5c1546d2-92be-4809-bc56-8bbdaab436d2}) of ThingClass kostalInverter</extracomment>
         <translation>Gesamte produzierte Energie</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="170"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="167"/>
         <source>Total imported energy</source>
         <extracomment>The name of the StateType ({f40e8bd9-db0e-4f69-8fa1-f1cfd4b144f3}) of ThingClass kostalMeter</extracomment>
         <translation>Gesamte importierte Energie</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="173"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="170"/>
         <source>Total real power</source>
         <extracomment>The name of the StateType ({6d72ccea-7761-4f00-b43f-463d05cbe559}) of ThingClass kostalBattery</extracomment>
         <translation>Gesamte Leistung</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="176"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="173"/>
+        <source>Total returned energy</source>
+        <extracomment>The name of the StateType ({902ce047-ef6b-4868-9f7c-61a2ebe61a5b}) of ThingClass kostalMeter</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="176"/>
         <source>Voltage</source>
         <extracomment>The name of the StateType ({176420b8-64b6-42e1-beea-9ce2a12f3261}) of ThingClass kostalBattery</extracomment>
         <translation>Spannung</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="179"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="182"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="179"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="182"/>
         <source>Voltage phase A</source>
         <extracomment>The name of the StateType ({10a34381-cfb1-4aeb-a25f-e6b0d8b96510}) of ThingClass kostalMeter
 ----------
@@ -231,8 +231,8 @@ The name of the StateType ({7fcade2d-9243-4694-a29f-36a517f54844}) of ThingClass
         <translation>Spannung Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="185"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="188"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="185"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="188"/>
         <source>Voltage phase B</source>
         <extracomment>The name of the StateType ({b0be1395-c7d2-449e-9632-5b6bf3298797}) of ThingClass kostalMeter
 ----------
@@ -240,8 +240,8 @@ The name of the StateType ({8f1b229d-af39-47ec-b005-eecd6f174294}) of ThingClass
         <translation>Spannung Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="191"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="194"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="191"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="194"/>
         <source>Voltage phase C</source>
         <extracomment>The name of the StateType ({b422d7a9-4c43-4827-be39-e4694f2cab64}) of ThingClass kostalMeter
 ----------

--- a/kostal/translations/51a2c7d5-084d-4474-a65a-e0447ab9ac45-en_US.ts
+++ b/kostal/translations/51a2c7d5-084d-4474-a65a-e0447ab9ac45-en_US.ts
@@ -19,7 +19,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginkostal.cpp" line="362"/>
+        <location filename="../integrationpluginkostal.cpp" line="364"/>
         <source>Could not initialize the communication with the inverter.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27,45 +27,39 @@
 <context>
     <name>Kostal</name>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="68"/>
-        <source>AC energy</source>
-        <extracomment>The name of the StateType ({902ce047-ef6b-4868-9f7c-61a2ebe61a5b}) of ThingClass kostalMeter</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="71"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="68"/>
         <source>Active power</source>
         <extracomment>The name of the StateType ({bd68fa44-2628-4e4e-ac9b-5f2cf563eb4d}) of ThingClass kostalInverter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="74"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="71"/>
         <source>Battery critical</source>
         <extracomment>The name of the StateType ({897616db-e815-4cda-b890-13b37a94ad17}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="77"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="74"/>
         <source>Battery level</source>
         <extracomment>The name of the StateType ({a4b0c8c9-44f0-43e2-ab25-63fdc9772fb8}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="80"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="77"/>
         <source>Capacity</source>
         <extracomment>The name of the StateType ({98099dbd-3f66-43b3-8192-f2e3fdcd5d62}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="83"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="80"/>
         <source>Charging state</source>
         <extracomment>The name of the StateType ({829173e8-7535-4aba-b403-d498ff68250e}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="86"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="89"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="92"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="83"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="86"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="89"/>
         <source>Connected</source>
         <extracomment>The name of the StateType ({4a5a5a38-b623-4024-b557-410a46ebc495}) of ThingClass kostalBattery
 ----------
@@ -75,14 +69,14 @@ The name of the StateType ({8d64954a-855d-44ea-8bc9-88a71ab47b6b}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="95"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="92"/>
         <source>Current power</source>
         <extracomment>The name of the StateType ({992b0da8-e6bd-47ab-af60-be8802fc7ecf}) of ThingClass kostalMeter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="98"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="101"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="95"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="98"/>
         <source>Current power phase A</source>
         <extracomment>The name of the StateType ({2b1250eb-4c22-4025-ba7c-c3e8f27af3dc}) of ThingClass kostalMeter
 ----------
@@ -90,8 +84,8 @@ The name of the StateType ({aed44263-d15e-46d6-b6a3-66005ceb53c9}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="104"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="107"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="101"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="104"/>
         <source>Current power phase B</source>
         <extracomment>The name of the StateType ({0c43d20d-843c-4edd-9955-dafab6caecf6}) of ThingClass kostalMeter
 ----------
@@ -99,8 +93,8 @@ The name of the StateType ({8d8cd634-00dd-46c8-b34b-bbff552d0121}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="110"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="113"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="107"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="110"/>
         <source>Current power phase C</source>
         <extracomment>The name of the StateType ({a1e46df0-43e5-42f0-846a-5d2f24808a67}) of ThingClass kostalMeter
 ----------
@@ -108,8 +102,8 @@ The name of the StateType ({95f1ad78-0cb1-44cf-87b2-03e28b115f00}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="116"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="119"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="113"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="116"/>
         <source>Frequency</source>
         <extracomment>The name of the StateType ({7c86ea72-505b-4924-80ef-3cf3ff31a380}) of ThingClass kostalMeter
 ----------
@@ -117,44 +111,44 @@ The name of the StateType ({634a4659-5c73-40e9-a77d-4f2e555d05bb}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="122"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="119"/>
         <source>KOSTAL Battery</source>
         <extracomment>The name of the ThingClass ({d6dbdfe8-adbb-47d8-840d-9b787683fc69})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="125"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="122"/>
         <source>KOSTAL Inverter</source>
         <extracomment>The name of the ThingClass ({7dc6db14-6f5a-4ac8-9684-4c6a526bd0de})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="128"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="125"/>
         <source>KOSTAL Meter</source>
         <extracomment>The name of the ThingClass ({61af1e07-6a59-4465-a563-3cbf4a9fcbc3})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="131"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="128"/>
         <source>KOSTAL Solar Electric</source>
         <extracomment>The name of the vendor ({862d1ebf-cb78-4c55-89b2-819fddfd9acd})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="134"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="131"/>
         <source>Kostal</source>
         <extracomment>The name of the plugin Kostal ({51a2c7d5-084d-4474-a65a-e0447ab9ac45})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="137"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="134"/>
         <source>MAC address</source>
         <extracomment>The name of the ParamType (ThingClass: kostalInverter, Type: thing, ID: {906f6099-d0e1-4297-a2b3-f8ec4482c578})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="140"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="143"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="137"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="140"/>
         <source>Phase A current</source>
         <extracomment>The name of the StateType ({1681ee7d-5d22-4794-8cfe-febaa1ddf29f}) of ThingClass kostalMeter
 ----------
@@ -162,8 +156,8 @@ The name of the StateType ({567bb3c2-4a0c-4194-a86e-b8dc29815092}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="146"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="149"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="143"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="146"/>
         <source>Phase B current</source>
         <extracomment>The name of the StateType ({b54e7182-6cb2-4184-96c5-2324e8139b6e}) of ThingClass kostalMeter
 ----------
@@ -171,8 +165,8 @@ The name of the StateType ({84e9282a-b72b-4dbf-9e4b-99083e5539a5}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="152"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="155"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="149"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="152"/>
         <source>Phase C current</source>
         <extracomment>The name of the StateType ({546eeb76-b17f-4c51-a9fa-01e7403913cd}) of ThingClass kostalMeter
 ----------
@@ -180,50 +174,56 @@ The name of the StateType ({4f7c308f-2cb2-4327-8a68-77222f920e61}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="158"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="155"/>
         <source>Port</source>
         <extracomment>The name of the ParamType (ThingClass: kostalInverter, Type: thing, ID: {9d2175af-afb9-4b31-b3dc-e53a369bad9e})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="161"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="158"/>
         <source>Slave ID</source>
         <extracomment>The name of the ParamType (ThingClass: kostalInverter, Type: thing, ID: {b3e04cb0-8f9a-4c9f-9c67-5c08da0273e3})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="164"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="161"/>
         <source>Temperature</source>
         <extracomment>The name of the StateType ({47b07030-57eb-4c79-a469-87b2474eb312}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="167"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="164"/>
         <source>Total energy produced</source>
         <extracomment>The name of the StateType ({5c1546d2-92be-4809-bc56-8bbdaab436d2}) of ThingClass kostalInverter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="170"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="167"/>
         <source>Total imported energy</source>
         <extracomment>The name of the StateType ({f40e8bd9-db0e-4f69-8fa1-f1cfd4b144f3}) of ThingClass kostalMeter</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="173"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="170"/>
         <source>Total real power</source>
         <extracomment>The name of the StateType ({6d72ccea-7761-4f00-b43f-463d05cbe559}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="176"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="173"/>
+        <source>Total returned energy</source>
+        <extracomment>The name of the StateType ({902ce047-ef6b-4868-9f7c-61a2ebe61a5b}) of ThingClass kostalMeter</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="176"/>
         <source>Voltage</source>
         <extracomment>The name of the StateType ({176420b8-64b6-42e1-beea-9ce2a12f3261}) of ThingClass kostalBattery</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="179"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="182"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="179"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="182"/>
         <source>Voltage phase A</source>
         <extracomment>The name of the StateType ({10a34381-cfb1-4aeb-a25f-e6b0d8b96510}) of ThingClass kostalMeter
 ----------
@@ -231,8 +231,8 @@ The name of the StateType ({7fcade2d-9243-4694-a29f-36a517f54844}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="185"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="188"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="185"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="188"/>
         <source>Voltage phase B</source>
         <extracomment>The name of the StateType ({b0be1395-c7d2-449e-9632-5b6bf3298797}) of ThingClass kostalMeter
 ----------
@@ -240,8 +240,8 @@ The name of the StateType ({8f1b229d-af39-47ec-b005-eecd6f174294}) of ThingClass
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="191"/>
-        <location filename="../../../build-nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="194"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="191"/>
+        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/kostal/plugininfo.h" line="194"/>
         <source>Voltage phase C</source>
         <extracomment>The name of the StateType ({b422d7a9-4c43-4827-be39-e4694f2cab64}) of ThingClass kostalMeter
 ----------


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?
