### PR TITLE
Mennekes: Add firmware version check and workaround erraneously signalled 0A max

### DIFF
--- a/mennekes/integrationpluginmennekes.cpp
+++ b/mennekes/integrationpluginmennekes.cpp
@@ -427,8 +427,13 @@ void IntegrationPluginMennekes::setupAmtronECUConnection(ThingSetupInfo *info)
         qCDebug(dcMennekes()) << "min current limit changed:" << minCurrentLimit;
         thing->setStateMinValue(amtronECUMaxChargingCurrentStateTypeId, minCurrentLimit);
     });
-    connect(amtronECUConnection, &AmtronECUModbusTcpConnection::maxCurrentLimitChanged, thing, [thing](quint16 maxCurrentLimit) {
+    connect(amtronECUConnection, &AmtronECUModbusTcpConnection::maxCurrentLimitChanged, thing, [this, thing](quint16 maxCurrentLimit) {
         qCDebug(dcMennekes()) << "max current limit changed:" << maxCurrentLimit;
+        // If the vehicle or cable are not capable of reporting the maximum, this will be 0
+        // We'll reset to the max defined in the json file in that case
+        if (maxCurrentLimit == 0) {
+            maxCurrentLimit = supportedThings().findById(amtronECUThingClassId).stateTypes().findById(amtronECUMaxChargingCurrentStateTypeId).maxValue().toUInt();
+        }
         thing->setStateMaxValue(amtronECUMaxChargingCurrentStateTypeId, maxCurrentLimit);
     });
     connect(amtronECUConnection, &AmtronECUModbusTcpConnection::hemsCurrentLimitChanged, thing, [thing](quint16 hemsCurrentLimit) {

--- a/mennekes/integrationpluginmennekes.cpp
+++ b/mennekes/integrationpluginmennekes.cpp
@@ -389,6 +389,16 @@ void IntegrationPluginMennekes::setupAmtronECUConnection(ThingSetupInfo *info)
         }
 
         qCDebug(dcMennekes()) << "Connection init finished successfully" << amtronECUConnection;
+
+        QString minimumVersion = "5.22";
+        if (!ensureAmtronECUVersion(amtronECUConnection, minimumVersion)) {
+            qCWarning(dcMennekes()) << "Firmware version too old:" << QByteArray::fromHex(QByteArray::number(amtronECUConnection->firmwareVersion(), 16)) << "Minimum required:" << minimumVersion;
+            hardwareManager()->networkDeviceDiscovery()->unregisterMonitor(monitor);
+            amtronECUConnection->deleteLater();
+            info->finish(Thing::ThingErrorHardwareFailure, QT_TR_NOOP("The firmware version of this wallbox is too old. Please upgrade the firmware to at least version 5.22."));
+            return;
+        }
+
         m_amtronECUConnections.insert(thing, amtronECUConnection);
         info->finish(Thing::ThingErrorNoError);
 

--- a/mennekes/translations/c7c3c65c-a0cc-4ab1-90d8-4ad05bfcdc38-en_US.ts
+++ b/mennekes/translations/c7c3c65c-a0cc-4ab1-90d8-4ad05bfcdc38-en_US.ts
@@ -9,21 +9,26 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginmennekes.cpp" line="127"/>
-        <location filename="../integrationpluginmennekes.cpp" line="177"/>
+        <location filename="../integrationpluginmennekes.cpp" line="133"/>
+        <location filename="../integrationpluginmennekes.cpp" line="183"/>
         <source>The MAC address is not known. Please reconfigure the thing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginmennekes.cpp" line="138"/>
-        <location filename="../integrationpluginmennekes.cpp" line="188"/>
+        <location filename="../integrationpluginmennekes.cpp" line="144"/>
+        <location filename="../integrationpluginmennekes.cpp" line="194"/>
         <source>The host address is not known yet. Trying later again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginmennekes.cpp" line="372"/>
-        <location filename="../integrationpluginmennekes.cpp" line="497"/>
+        <location filename="../integrationpluginmennekes.cpp" line="387"/>
+        <location filename="../integrationpluginmennekes.cpp" line="515"/>
         <source>Error communicating with the wallbox.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../integrationpluginmennekes.cpp" line="398"/>
+        <source>The firmware version of this wallbox is too old. Please upgrade the firmware to at least version 5.22.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?
