### PR TITLE
B+G E-Tech: Add support for SDM72.

### DIFF
--- a/bgetech/README.md
+++ b/bgetech/README.md
@@ -1,9 +1,9 @@
 # B+G E-Tech
 
-This plugin adds support for the B+G E-Tech SDM630 energy meter connected via Modbus RTU.
+This plugin adds support for the B+G E-Tech SDM630 and SDM72 energy meter connected via Modbus RTU.
 
 # Setup instructions
 First, set up a Modbus RTU resource using the configured settings of your meter. Once
-that's set up, the SDM630 can be set up like any other thing. During discovery, nymea will
+that's set up, the SDM630 and SDM72 can be set up like any other thing. During discovery, nymea will
 offer the configured Modbus resources as possible connections. Select the one that
 you've set up previously.

--- a/bgetech/bgetech.pro
+++ b/bgetech/bgetech.pro
@@ -1,7 +1,7 @@
 include(../plugins.pri)
 
 # Generate modbus connection
-MODBUS_CONNECTIONS += sdm630-registers.json
+MODBUS_CONNECTIONS += sdm630-registers.json sdm72-registers.json
 #MODBUS_TOOLS_CONFIG += VERBOSE
 include(../modbus.pri)
 

--- a/bgetech/integrationpluginbgetech.cpp
+++ b/bgetech/integrationpluginbgetech.cpp
@@ -1,4 +1,4 @@
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+﻿/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 *
 * Copyright 2013 - 2021, nymea GmbH
 * Contact: contact@nymea.io
@@ -26,6 +26,9 @@
 * contact@nymea.io or see our FAQ/Licensing Information on
 * https://nymea.io/license/faq
 *
+*
+* SDM72 added by Consolinno Energy GmbH
+*
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "integrationpluginbgetech.h"
@@ -41,10 +44,18 @@ void IntegrationPluginBGETech::init()
         qCDebug(dcBgeTech()) << "Modbus RTU master has been removed" << modbusUuid.toString();
 
         foreach (Thing *thing, myThings()) {
-            if (thing->paramValue(sdm630ThingModbusMasterUuidParamTypeId) == modbusUuid) {
-                qCWarning(dcBgeTech()) << "Modbus RTU hardware resource removed for" << thing << ". The thing will not be functional any more until a new resource has been configured for it.";
-                thing->setStateValue(sdm630ConnectedStateTypeId, false);
-                delete m_sdmConnections.take(thing);
+            if (thing->thingClassId() == sdm630ThingClassId) {
+                if (thing->paramValue(sdm630ThingModbusMasterUuidParamTypeId) == modbusUuid) {
+                    qCWarning(dcBgeTech()) << "Modbus RTU hardware resource removed for" << thing << ". The thing will not be functional any more until a new resource has been configured for it.";
+                    thing->setStateValue(sdm630ConnectedStateTypeId, false);
+                    delete m_sdm630Connections.take(thing);
+                }
+            } else if (thing->thingClassId() == sdm72ThingClassId) {
+                if (thing->paramValue(sdm72ThingModbusMasterUuidParamTypeId) == modbusUuid) {
+                    qCWarning(dcBgeTech()) << "Modbus RTU hardware resource removed for" << thing << ". The thing will not be functional any more until a new resource has been configured for it.";
+                    thing->setStateValue(sdm72ConnectedStateTypeId, false);
+                    delete m_sdm72Connections.take(thing);
+                }
             }
         }
     });
@@ -58,27 +69,51 @@ void IntegrationPluginBGETech::discoverThings(ThingDiscoveryInfo *info)
         return;
     }
 
-    uint slaveAddress = info->params().paramValue(sdm630DiscoverySlaveAddressParamTypeId).toUInt();
-    if (slaveAddress > 254 || slaveAddress == 0) {
-        info->finish(Thing::ThingErrorInvalidParameter, QT_TR_NOOP("The Modbus slave address must be a value between 1 and 254."));
+    if (info->thingClassId() == sdm630ThingClassId) {
+        uint slaveAddress = info->params().paramValue(sdm630DiscoverySlaveAddressParamTypeId).toUInt();
+        if (slaveAddress > 254 || slaveAddress == 0) {
+            info->finish(Thing::ThingErrorInvalidParameter, QT_TR_NOOP("The Modbus slave address must be a value between 1 and 254."));
+            return;
+        }
+
+        foreach (ModbusRtuMaster *modbusMaster, hardwareManager()->modbusRtuResource()->modbusRtuMasters()) {
+            qCDebug(dcBgeTech()) << "Found RTU master resource" << modbusMaster << "connected" << modbusMaster->connected();
+            if (!modbusMaster->connected())
+                continue;
+
+            ThingDescriptor descriptor(info->thingClassId(), "SDM630", QString::number(slaveAddress) + " " + modbusMaster->serialPort());
+            ParamList params;
+            params << Param(sdm630ThingSlaveAddressParamTypeId, slaveAddress);
+            params << Param(sdm630ThingModbusMasterUuidParamTypeId, modbusMaster->modbusUuid());
+            descriptor.setParams(params);
+            info->addThingDescriptor(descriptor);
+        }
+
+        info->finish(Thing::ThingErrorNoError);
+        return;
+    } else if (info->thingClassId() == sdm72ThingClassId) {
+        uint slaveAddress = info->params().paramValue(sdm72DiscoverySlaveAddressParamTypeId).toUInt();
+        if (slaveAddress > 254 || slaveAddress == 0) {
+            info->finish(Thing::ThingErrorInvalidParameter, QT_TR_NOOP("The Modbus slave address must be a value between 1 and 254."));
+            return;
+        }
+
+        foreach (ModbusRtuMaster *modbusMaster, hardwareManager()->modbusRtuResource()->modbusRtuMasters()) {
+            qCDebug(dcBgeTech()) << "Found RTU master resource" << modbusMaster << "connected" << modbusMaster->connected();
+            if (!modbusMaster->connected())
+                continue;
+
+            ThingDescriptor descriptor(info->thingClassId(), "SDM72", QString::number(slaveAddress) + " " + modbusMaster->serialPort());
+            ParamList params;
+            params << Param(sdm72ThingSlaveAddressParamTypeId, slaveAddress);
+            params << Param(sdm72ThingModbusMasterUuidParamTypeId, modbusMaster->modbusUuid());
+            descriptor.setParams(params);
+            info->addThingDescriptor(descriptor);
+        }
+
+        info->finish(Thing::ThingErrorNoError);
         return;
     }
-
-    foreach (ModbusRtuMaster *modbusMaster, hardwareManager()->modbusRtuResource()->modbusRtuMasters()) {
-        qCDebug(dcBgeTech()) << "Found RTU master resource" << modbusMaster << "connected" << modbusMaster->connected();
-        if (!modbusMaster->connected())
-            continue;
-
-        ThingDescriptor descriptor(info->thingClassId(), "SDM630", QString::number(slaveAddress) + " " + modbusMaster->serialPort());
-        ParamList params;
-        params << Param(sdm630ThingSlaveAddressParamTypeId, slaveAddress);
-        params << Param(sdm630ThingModbusMasterUuidParamTypeId, modbusMaster->modbusUuid());
-        descriptor.setParams(params);
-        info->addThingDescriptor(descriptor);
-    }
-
-    info->finish(Thing::ThingErrorNoError);
-    return;
 }
 
 void IntegrationPluginBGETech::setupThing(ThingSetupInfo *info)
@@ -86,114 +121,202 @@ void IntegrationPluginBGETech::setupThing(ThingSetupInfo *info)
     Thing *thing = info->thing();
     qCDebug(dcBgeTech()) << "Setup thing" << thing << thing->params();
 
-    uint address = thing->paramValue(sdm630ThingSlaveAddressParamTypeId).toUInt();
-    if (address > 254 || address == 0) {
-        qCWarning(dcBgeTech()) << "Setup failed, slave address is not valid" << address;
-        info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Modbus address not valid. It must be a value between 1 and 254."));
-        return;
-    }
-
-    QUuid uuid = thing->paramValue(sdm630ThingModbusMasterUuidParamTypeId).toUuid();
-    if (!hardwareManager()->modbusRtuResource()->hasModbusRtuMaster(uuid)) {
-        qCWarning(dcBgeTech()) << "Setup failed, hardware manager not available";
-        info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Modbus RTU interface not available."));
-        return;
-    }
-
-    if (m_sdmConnections.contains(thing)) {
-        qCDebug(dcBgeTech()) << "Setup after rediscovery, cleaning up ...";
-        m_sdmConnections.take(thing)->deleteLater();
-    }
-
-    Sdm630ModbusRtuConnection *sdmConnection = new Sdm630ModbusRtuConnection(hardwareManager()->modbusRtuResource()->getModbusRtuMaster(uuid), address, this);
-    connect(sdmConnection->modbusRtuMaster(), &ModbusRtuMaster::connectedChanged, this, [=](bool connected){
-        if (connected) {
-            qCDebug(dcBgeTech()) << "Modbus RTU resource connected" << thing << sdmConnection->modbusRtuMaster()->serialPort();
-        } else {
-            qCWarning(dcBgeTech()) << "Modbus RTU resource disconnected" << thing << sdmConnection->modbusRtuMaster()->serialPort();
+    if (thing->thingClassId() == sdm630ThingClassId) {
+        uint address = thing->paramValue(sdm630ThingSlaveAddressParamTypeId).toUInt();
+        if (address > 254 || address == 0) {
+            qCWarning(dcBgeTech()) << "Setup failed, slave address is not valid" << address;
+            info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Modbus address not valid. It must be a value between 1 and 254."));
+            return;
         }
-    });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::currentPhaseAChanged, this, [=](float currentPhaseA){
-        thing->setStateValue(sdm630CurrentPhaseAStateTypeId, currentPhaseA);
-        thing->setStateValue(sdm630ConnectedStateTypeId, true);
-    });
+        QUuid uuid = thing->paramValue(sdm630ThingModbusMasterUuidParamTypeId).toUuid();
+        if (!hardwareManager()->modbusRtuResource()->hasModbusRtuMaster(uuid)) {
+            qCWarning(dcBgeTech()) << "Setup failed, hardware manager not available";
+            info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Modbus RTU interface not available."));
+            return;
+        }
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::currentPhaseBChanged, this, [=](float currentPhaseB){
-        thing->setStateValue(sdm630CurrentPhaseBStateTypeId, currentPhaseB);
-    });
+        if (m_sdm630Connections.contains(thing)) {
+            qCDebug(dcBgeTech()) << "Setup after rediscovery, cleaning up ...";
+            m_sdm630Connections.take(thing)->deleteLater();
+        }
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::currentPhaseCChanged, this, [=](float currentPhaseC){
-        thing->setStateValue(sdm630CurrentPhaseCStateTypeId, currentPhaseC);
-    });
+        Sdm630ModbusRtuConnection *sdmConnection = new Sdm630ModbusRtuConnection(hardwareManager()->modbusRtuResource()->getModbusRtuMaster(uuid), address, this);
+        connect(sdmConnection->modbusRtuMaster(), &ModbusRtuMaster::connectedChanged, this, [=](bool connected){
+            if (connected) {
+                qCDebug(dcBgeTech()) << "Modbus RTU resource connected" << thing << sdmConnection->modbusRtuMaster()->serialPort();
+            } else {
+                qCWarning(dcBgeTech()) << "Modbus RTU resource disconnected" << thing << sdmConnection->modbusRtuMaster()->serialPort();
+            }
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::voltagePhaseAChanged, this, [=](float voltagePhaseA){
-        thing->setStateValue(sdm630VoltagePhaseAStateTypeId, voltagePhaseA);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::currentPhaseAChanged, this, [=](float currentPhaseA){
+            thing->setStateValue(sdm630CurrentPhaseAStateTypeId, currentPhaseA);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::voltagePhaseBChanged, this, [=](float voltagePhaseB){
-        thing->setStateValue(sdm630VoltagePhaseBStateTypeId, voltagePhaseB);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::currentPhaseBChanged, this, [=](float currentPhaseB){
+            thing->setStateValue(sdm630CurrentPhaseBStateTypeId, currentPhaseB);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::voltagePhaseCChanged, this, [=](float voltagePhaseC){
-        thing->setStateValue(sdm630VoltagePhaseCStateTypeId, voltagePhaseC);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::currentPhaseCChanged, this, [=](float currentPhaseC){
+            thing->setStateValue(sdm630CurrentPhaseCStateTypeId, currentPhaseC);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::totalCurrentPowerChanged, this, [=](float currentPower){
-        thing->setStateValue(sdm630CurrentPowerStateTypeId, currentPower);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::voltagePhaseAChanged, this, [=](float voltagePhaseA){
+            thing->setStateValue(sdm630VoltagePhaseAStateTypeId, voltagePhaseA);
+            thing->setStateValue(sdm630ConnectedStateTypeId, true);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::powerPhaseAChanged, this, [=](float powerPhaseA){
-        thing->setStateValue(sdm630CurrentPowerPhaseAStateTypeId, powerPhaseA);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::voltagePhaseBChanged, this, [=](float voltagePhaseB){
+            thing->setStateValue(sdm630VoltagePhaseBStateTypeId, voltagePhaseB);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::powerPhaseBChanged, this, [=](float powerPhaseB){
-        thing->setStateValue(sdm630CurrentPowerPhaseBStateTypeId, powerPhaseB);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::voltagePhaseCChanged, this, [=](float voltagePhaseC){
+            thing->setStateValue(sdm630VoltagePhaseCStateTypeId, voltagePhaseC);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::powerPhaseCChanged, this, [=](float powerPhaseC){
-        thing->setStateValue(sdm630CurrentPowerPhaseCStateTypeId, powerPhaseC);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::totalCurrentPowerChanged, this, [=](float currentPower){
+            thing->setStateValue(sdm630CurrentPowerStateTypeId, currentPower);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::frequencyChanged, this, [=](float frequency){
-        thing->setStateValue(sdm630FrequencyStateTypeId, frequency);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::powerPhaseAChanged, this, [=](float powerPhaseA){
+            thing->setStateValue(sdm630CurrentPowerPhaseAStateTypeId, powerPhaseA);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::totalEnergyConsumedChanged, this, [=](float totalEnergyConsumed){
-        thing->setStateValue(sdm630TotalEnergyConsumedStateTypeId, totalEnergyConsumed);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::powerPhaseBChanged, this, [=](float powerPhaseB){
+            thing->setStateValue(sdm630CurrentPowerPhaseBStateTypeId, powerPhaseB);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::totalEnergyProducedChanged, this, [=](float totalEnergyProduced){
-        thing->setStateValue(sdm630TotalEnergyProducedStateTypeId, totalEnergyProduced);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::powerPhaseCChanged, this, [=](float powerPhaseC){
+            thing->setStateValue(sdm630CurrentPowerPhaseCStateTypeId, powerPhaseC);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::energyProducedPhaseAChanged, this, [=](float energyProducedPhaseA){
-        thing->setStateValue(sdm630EnergyProducedPhaseAStateTypeId, energyProducedPhaseA);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::frequencyChanged, this, [=](float frequency){
+            thing->setStateValue(sdm630FrequencyStateTypeId, frequency);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::energyProducedPhaseBChanged, this, [=](float energyProducedPhaseB){
-        thing->setStateValue(sdm630EnergyProducedPhaseBStateTypeId, energyProducedPhaseB);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::totalEnergyConsumedChanged, this, [=](float totalEnergyConsumed){
+            thing->setStateValue(sdm630TotalEnergyConsumedStateTypeId, totalEnergyConsumed);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::energyProducedPhaseCChanged, this, [=](float energyProducedPhaseC){
-        thing->setStateValue(sdm630EnergyProducedPhaseCStateTypeId, energyProducedPhaseC);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::totalEnergyProducedChanged, this, [=](float totalEnergyProduced){
+            thing->setStateValue(sdm630TotalEnergyProducedStateTypeId, totalEnergyProduced);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::energyConsumedPhaseAChanged, this, [=](float energyConsumedPhaseA){
-        thing->setStateValue(sdm630EnergyConsumedPhaseAStateTypeId, energyConsumedPhaseA);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::energyProducedPhaseAChanged, this, [=](float energyProducedPhaseA){
+            thing->setStateValue(sdm630EnergyProducedPhaseAStateTypeId, energyProducedPhaseA);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::energyConsumedPhaseBChanged, this, [=](float energyConsumedPhaseB){
-        thing->setStateValue(sdm630EnergyConsumedPhaseBStateTypeId, energyConsumedPhaseB);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::energyProducedPhaseBChanged, this, [=](float energyProducedPhaseB){
+            thing->setStateValue(sdm630EnergyProducedPhaseBStateTypeId, energyProducedPhaseB);
+        });
 
-    connect(sdmConnection, &Sdm630ModbusRtuConnection::energyConsumedPhaseCChanged, this, [=](float energyConsumedPhaseC){
-        thing->setStateValue(sdm630EnergyConsumedPhaseCStateTypeId, energyConsumedPhaseC);
-    });
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::energyProducedPhaseCChanged, this, [=](float energyProducedPhaseC){
+            thing->setStateValue(sdm630EnergyProducedPhaseCStateTypeId, energyProducedPhaseC);
+        });
 
-    // FIXME: try to read before setup success
-    m_sdmConnections.insert(thing, sdmConnection);
-    info->finish(Thing::ThingErrorNoError);
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::energyConsumedPhaseAChanged, this, [=](float energyConsumedPhaseA){
+            thing->setStateValue(sdm630EnergyConsumedPhaseAStateTypeId, energyConsumedPhaseA);
+        });
+
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::energyConsumedPhaseBChanged, this, [=](float energyConsumedPhaseB){
+            thing->setStateValue(sdm630EnergyConsumedPhaseBStateTypeId, energyConsumedPhaseB);
+        });
+
+        connect(sdmConnection, &Sdm630ModbusRtuConnection::energyConsumedPhaseCChanged, this, [=](float energyConsumedPhaseC){
+            thing->setStateValue(sdm630EnergyConsumedPhaseCStateTypeId, energyConsumedPhaseC);
+        });
+
+        // FIXME: try to read before setup success
+        m_sdm630Connections.insert(thing, sdmConnection);
+        info->finish(Thing::ThingErrorNoError);
+
+    } else if (thing->thingClassId() == sdm72ThingClassId) {
+        uint address = thing->paramValue(sdm72ThingSlaveAddressParamTypeId).toUInt();
+        if (address > 254 || address == 0) {
+            qCWarning(dcBgeTech()) << "Setup failed, slave address is not valid" << address;
+            info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Modbus address not valid. It must be a value between 1 and 254."));
+            return;
+        }
+
+        QUuid uuid = thing->paramValue(sdm72ThingModbusMasterUuidParamTypeId).toUuid();
+        if (!hardwareManager()->modbusRtuResource()->hasModbusRtuMaster(uuid)) {
+            qCWarning(dcBgeTech()) << "Setup failed, hardware manager not available";
+            info->finish(Thing::ThingErrorSetupFailed, QT_TR_NOOP("The Modbus RTU interface not available."));
+            return;
+        }
+
+        if (m_sdm72Connections.contains(thing)) {
+            qCDebug(dcBgeTech()) << "Setup after rediscovery, cleaning up ...";
+            m_sdm72Connections.take(thing)->deleteLater();
+        }
+
+        Sdm72ModbusRtuConnection *sdmConnection = new Sdm72ModbusRtuConnection(hardwareManager()->modbusRtuResource()->getModbusRtuMaster(uuid), address, this);
+        connect(sdmConnection->modbusRtuMaster(), &ModbusRtuMaster::connectedChanged, this, [=](bool connected){
+            if (connected) {
+                qCDebug(dcBgeTech()) << "Modbus RTU resource connected" << thing << sdmConnection->modbusRtuMaster()->serialPort();
+            } else {
+                qCWarning(dcBgeTech()) << "Modbus RTU resource disconnected" << thing << sdmConnection->modbusRtuMaster()->serialPort();
+            }
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::currentPhaseAChanged, this, [=](float currentPhaseA){
+            thing->setStateValue(sdm72CurrentPhaseAStateTypeId, currentPhaseA);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::currentPhaseBChanged, this, [=](float currentPhaseB){
+            thing->setStateValue(sdm72CurrentPhaseBStateTypeId, currentPhaseB);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::currentPhaseCChanged, this, [=](float currentPhaseC){
+            thing->setStateValue(sdm72CurrentPhaseCStateTypeId, currentPhaseC);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::voltagePhaseAChanged, this, [=](float voltagePhaseA){
+            thing->setStateValue(sdm72VoltagePhaseAStateTypeId, voltagePhaseA);
+            thing->setStateValue(sdm72ConnectedStateTypeId, true);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::voltagePhaseBChanged, this, [=](float voltagePhaseB){
+            thing->setStateValue(sdm72VoltagePhaseBStateTypeId, voltagePhaseB);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::voltagePhaseCChanged, this, [=](float voltagePhaseC){
+            thing->setStateValue(sdm72VoltagePhaseCStateTypeId, voltagePhaseC);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::totalCurrentPowerChanged, this, [=](float currentPower){
+            thing->setStateValue(sdm72CurrentPowerStateTypeId, currentPower);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::powerPhaseAChanged, this, [=](float powerPhaseA){
+            thing->setStateValue(sdm72CurrentPowerPhaseAStateTypeId, powerPhaseA);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::powerPhaseBChanged, this, [=](float powerPhaseB){
+            thing->setStateValue(sdm72CurrentPowerPhaseBStateTypeId, powerPhaseB);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::powerPhaseCChanged, this, [=](float powerPhaseC){
+            thing->setStateValue(sdm72CurrentPowerPhaseCStateTypeId, powerPhaseC);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::frequencyChanged, this, [=](float frequency){
+            thing->setStateValue(sdm72FrequencyStateTypeId, frequency);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::totalEnergyConsumedChanged, this, [=](float totalEnergyConsumed){
+            thing->setStateValue(sdm72TotalEnergyConsumedStateTypeId, totalEnergyConsumed);
+        });
+
+        connect(sdmConnection, &Sdm72ModbusRtuConnection::totalEnergyProducedChanged, this, [=](float totalEnergyProduced){
+            thing->setStateValue(sdm72TotalEnergyProducedStateTypeId, totalEnergyProduced);
+        });
+
+        // FIXME: try to read before setup success
+        m_sdm72Connections.insert(thing, sdmConnection);
+        info->finish(Thing::ThingErrorNoError);
+    }
 }
 
 void IntegrationPluginBGETech::postSetupThing(Thing *thing)
@@ -203,7 +326,11 @@ void IntegrationPluginBGETech::postSetupThing(Thing *thing)
         m_refreshTimer = hardwareManager()->pluginTimerManager()->registerTimer(2);
         connect(m_refreshTimer, &PluginTimer::timeout, this, [this] {
             foreach (Thing *thing, myThings()) {
-                m_sdmConnections.value(thing)->update();
+                if (thing->thingClassId() == sdm630ThingClassId) {
+                    m_sdm630Connections.value(thing)->update();
+                } else if (thing->thingClassId() == sdm72ThingClassId) {
+                    m_sdm72Connections.value(thing)->update();
+                }
             }
         });
 
@@ -216,8 +343,11 @@ void IntegrationPluginBGETech::thingRemoved(Thing *thing)
 {
     qCDebug(dcBgeTech()) << "Thing removed" << thing->name();
 
-    if (m_sdmConnections.contains(thing))
-        m_sdmConnections.take(thing)->deleteLater();
+    if (m_sdm630Connections.contains(thing))
+        m_sdm630Connections.take(thing)->deleteLater();
+
+    if (m_sdm72Connections.contains(thing))
+        m_sdm72Connections.take(thing)->deleteLater();
 
     if (myThings().isEmpty() && m_refreshTimer) {
         qCDebug(dcBgeTech()) << "Stopping reconnect timer";

--- a/bgetech/integrationpluginbgetech.h
+++ b/bgetech/integrationpluginbgetech.h
@@ -36,6 +36,7 @@
 #include <plugintimer.h>
 
 #include "sdm630modbusrtuconnection.h"
+#include "sdm72modbusrtuconnection.h"
 
 #include "extern-plugininfo.h"
 
@@ -60,7 +61,8 @@ public:
 private:
     PluginTimer *m_refreshTimer = nullptr;
 
-    QHash<Thing *, Sdm630ModbusRtuConnection *> m_sdmConnections;
+    QHash<Thing *, Sdm630ModbusRtuConnection *> m_sdm630Connections;
+    QHash<Thing *, Sdm72ModbusRtuConnection *> m_sdm72Connections;
 };
 
 #endif // INTEGRATIONPLUGINBGETECH_H

--- a/bgetech/integrationpluginbgetech.json
+++ b/bgetech/integrationpluginbgetech.json
@@ -223,6 +223,167 @@
                             "defaultValue": 0.00
                         }
                     ]
+                },
+                {
+                    "name": "sdm72",
+                    "displayName": "SDM72",
+                    "id": "ce54ada6-cbe8-406a-9262-c707c4d8c392",
+                    "createMethods": ["discovery"],
+                    "interfaces": ["energymeter", "connectable"],
+                    "discoveryParamTypes": [
+                        {
+                            "id": "27219539-443b-43dc-ad8b-11e7cfb862b5",
+                            "name": "slaveAddress",
+                            "displayName": "Slave address",
+                            "type": "int",
+                            "defaultValue": 1
+                        }
+                    ],
+                    "paramTypes": [
+                        {
+                            "id": "6ec32145-f77c-4268-ae1d-159f9702fd85",
+                            "name": "slaveAddress",
+                            "displayName": "Modbus slave address",
+                            "type": "uint",
+                            "defaultValue": 1
+                        },
+                        {
+                            "id": "6edc9c2b-e939-4c24-ac81-fc3ca17aab3f",
+                            "name": "modbusMasterUuid",
+                            "displayName": "Modbus RTU master",
+                            "type": "QUuid",
+                            "defaultValue": "",
+                            "readOnly": true
+                        }
+                    ],
+                    "stateTypes": [
+                        {
+                            "id": "3b69f8e9-1788-4b71-8bd6-bece89f1d045",
+                            "name": "connected",
+                            "displayName": "Connected",
+                            "displayNameEvent": "Connected changed",
+                            "type": "bool",
+                            "cached": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "id": "15b5e57b-7584-4be0-9053-55bb495435a5",
+                            "name": "voltagePhaseA",
+                            "displayName": "Voltage phase A",
+                            "displayNameEvent": "Voltage phase A changed",
+                            "type": "double",
+                            "unit": "Volt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "998cf8e7-38e9-433a-8ef5-726b45bbfc63",
+                            "name": "voltagePhaseB",
+                            "displayName": "Voltage phase B",
+                            "displayNameEvent": "Voltage phase B changed",
+                            "type": "double",
+                            "unit": "Volt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "48164e10-0217-45e2-bf8f-5ec396c43ceb",
+                            "name": "voltagePhaseC",
+                            "displayName": "Voltage phase C",
+                            "displayNameEvent": "Voltage phase C changed",
+                            "type": "double",
+                            "unit": "Volt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "154e1c19-34c5-4e82-ab4b-b4476b7deb18",
+                            "name": "currentPhaseA",
+                            "displayName": "Current phase A",
+                            "displayNameEvent": "Current phase A changed",
+                            "type": "double",
+                            "unit": "Ampere",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "210c5ab5-09ab-48e5-89aa-d932aae5215f",
+                            "name": "currentPhaseB",
+                            "displayName": "Current phase B",
+                            "displayNameEvent": "Current phase B changed",
+                            "type": "double",
+                            "unit": "Ampere",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "abcfd3ee-6065-421d-bcfc-8c5087aacb46",
+                            "name": "currentPhaseC",
+                            "displayName": "Current phase C",
+                            "displayNameEvent": "Current phase C changed",
+                            "type": "double",
+                            "unit": "Ampere",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "d53b97fd-217a-47b6-a73b-f963ece553b2",
+                            "name": "currentPower",
+                            "displayName": "Current power",
+                            "displayNameEvent": "Current power changed",
+                            "type": "double",
+                            "unit": "Watt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "c0d7071c-22f7-4ba7-8158-b297fd8a0929",
+                            "name": "currentPowerPhaseA",
+                            "displayName": "Current power phase A",
+                            "displayNameEvent": "Current power phase A changed",
+                            "type": "double",
+                            "unit": "Watt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "3dd97cae-a03c-4afc-9366-0c135e8c2443",
+                            "name": "currentPowerPhaseB",
+                            "displayName": "Current power phase B",
+                            "displayNameEvent": "Current power phase B changed",
+                            "type": "double",
+                            "unit": "Watt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "e4043c04-2410-41ff-acab-65883b7a8569",
+                            "name": "currentPowerPhaseC",
+                            "displayName": "Current power phase C",
+                            "displayNameEvent": "Current power phase C changed",
+                            "type": "double",
+                            "unit": "Watt",
+                            "defaultValue": 0
+                        },
+                        {
+                            "id": "724821e6-1975-4a38-907a-a853b10480bd",
+                            "name": "frequency",
+                            "displayName": "Frequency",
+                            "displayNameEvent": "Frequency changed",
+                            "type": "double",
+                            "unit": "Hertz",
+                            "defaultValue": 0.00
+                        },
+                        {
+                            "id": "8a9a9212-21aa-4d5a-a528-7781a087f3a2",
+                            "name": "totalEnergyConsumed",
+                            "displayName": "Total energy consumed",
+                            "displayNameEvent": "Total energy consumed changed",
+                            "type": "double",
+                            "unit": "KiloWattHour",
+                            "defaultValue": 0.00
+                        },
+                        {
+                            "id": "7b8592ca-2173-459e-85ab-9b4aec4970c6",
+                            "name": "totalEnergyProduced",
+                            "displayName": "Total energy produced",
+                            "displayNameEvent": "Total energy produced changed",
+                            "type": "double",
+                            "unit": "KiloWattHour",
+                            "defaultValue": 0.00
+                        }
+                    ]
                 }
             ]
         }

--- a/bgetech/sdm72-registers.json
+++ b/bgetech/sdm72-registers.json
@@ -1,5 +1,5 @@
 {
-    "className": "Sdm630",
+    "className": "Sdm72",
     "protocol": "RTU",
     "endianness": "BigEndian",
     "errorLimitUntilNotReachable": 15,
@@ -175,84 +175,6 @@
                     "registerType": "inputRegister",
                     "readSchedule": "update",
                     "description": "Total energy produced",
-                    "unit": "kWh",
-                    "defaultValue": "0",
-                    "access": "RO"
-                }
-            ]
-        },
-        {
-            "id": "phaseEnergyEnergy",
-            "readSchedule": "update",
-            "registers": [
-                {
-                    "id": "energyProducedPhaseA",
-                    "address": 346,
-                    "size": 2,
-                    "type": "float",
-                    "registerType": "inputRegister",
-                    "readSchedule": "update",
-                    "description": "Energy produced phase A",
-                    "unit": "kWh",
-                    "defaultValue": "0",
-                    "access": "RO"
-                },
-                {
-                    "id": "energyProducedPhaseB",
-                    "address": 348,
-                    "size": 2,
-                    "type": "float",
-                    "registerType": "inputRegister",
-                    "readSchedule": "update",
-                    "description": "Energy produced phase B",
-                    "unit": "kWh",
-                    "defaultValue": "0",
-                    "access": "RO"
-                },
-                {
-                    "id": "energyProducedPhaseC",
-                    "address": 350,
-                    "size": 2,
-                    "type": "float",
-                    "registerType": "inputRegister",
-                    "readSchedule": "update",
-                    "description": "Energy produced phase C",
-                    "unit": "kWh",
-                    "defaultValue": "0",
-                    "access": "RO"
-                },
-                {
-                    "id": "energyConsumedPhaseA",
-                    "address": 352,
-                    "size": 2,
-                    "type": "float",
-                    "registerType": "inputRegister",
-                    "readSchedule": "update",
-                    "description": "Energy consumed phase A",
-                    "unit": "kWh",
-                    "defaultValue": "0",
-                    "access": "RO"
-                },
-                {
-                    "id": "energyConsumedPhaseB",
-                    "address": 354,
-                    "size": 2,
-                    "type": "float",
-                    "registerType": "inputRegister",
-                    "readSchedule": "update",
-                    "description": "Energy consumed phase B",
-                    "unit": "kWh",
-                    "defaultValue": "0",
-                    "access": "RO"
-                },
-                {
-                    "id": "energyConsumedPhaseC",
-                    "address": 356,
-                    "size": 2,
-                    "type": "float",
-                    "registerType": "inputRegister",
-                    "readSchedule": "update",
-                    "description": "Energy consumed phase C",
                     "unit": "kWh",
                     "defaultValue": "0",
                     "access": "RO"

--- a/bgetech/translations/e373f492-4527-4d5f-aa48-34d38c55b0d6-de.ts
+++ b/bgetech/translations/e373f492-4527-4d5f-aa48-34d38c55b0d6-de.ts
@@ -4,22 +4,25 @@
 <context>
     <name>IntegrationPluginBGETech</name>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="57"/>
+        <location filename="../integrationpluginbgetech.cpp" line="65"/>
         <source>No Modbus RTU interface available. Please set up the Modbus RTU interface first.</source>
         <translation>Keine Modbus RTU Schnittstelle verfügbar. Bitte richte zuerst die Modbus RTU Schnittstelle ein.</translation>
     </message>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="63"/>
+        <location filename="../integrationpluginbgetech.cpp" line="72"/>
+        <location filename="../integrationpluginbgetech.cpp" line="94"/>
         <source>The Modbus slave address must be a value between 1 and 254.</source>
         <translation>Die Modbus Adresse muss ein Wert zwischen 1 und 254 sein.</translation>
     </message>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="92"/>
+        <location filename="../integrationpluginbgetech.cpp" line="125"/>
+        <location filename="../integrationpluginbgetech.cpp" line="235"/>
         <source>The Modbus address not valid. It must be a value between 1 and 254.</source>
         <translation>Die Modbus Adresse is ungültig. Sie muss ein Wert zwischen 1 und 254 sein.</translation>
     </message>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="99"/>
+        <location filename="../integrationpluginbgetech.cpp" line="132"/>
+        <location filename="../integrationpluginbgetech.cpp" line="242"/>
         <source>The Modbus RTU interface not available.</source>
         <translation>Die Modbus RTU Schnittstelle ist nicht verfügbar.</translation>
     </message>
@@ -27,8 +30,8 @@
 <context>
     <name>bgeTech</name>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="91"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="94"/>
+        <location filename="../plugininfo.h" line="69"/>
+        <location filename="../plugininfo.h" line="72"/>
         <source>B+G E-Tech</source>
         <extracomment>The name of the vendor ({215035fe-95e8-43d8-a52e-0a31b787d902})
 ----------
@@ -36,328 +39,205 @@ The name of the plugin bgeTech ({e373f492-4527-4d5f-aa48-34d38c55b0d6})</extraco
         <translation>B+G E-Tech</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="97"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="100"/>
+        <location filename="../plugininfo.h" line="75"/>
+        <location filename="../plugininfo.h" line="78"/>
         <source>Connected</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: connected, ID: {8050bd0b-1dad-4a7e-b632-c71ead3c9f8b})
+        <extracomment>The name of the StateType ({3b69f8e9-1788-4b71-8bd6-bece89f1d045}) of ThingClass sdm72
 ----------
 The name of the StateType ({8050bd0b-1dad-4a7e-b632-c71ead3c9f8b}) of ThingClass sdm630</extracomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="103"/>
-        <source>Connected changed</source>
-        <extracomment>The name of the EventType ({8050bd0b-1dad-4a7e-b632-c71ead3c9f8b}) of ThingClass sdm630</extracomment>
-        <translation>Verbunden oder getrennt</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="106"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="109"/>
+        <location filename="../plugininfo.h" line="81"/>
+        <location filename="../plugininfo.h" line="84"/>
         <source>Current phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPhaseA, ID: {4baf1d08-5ffa-49cf-95ef-9527b0c6f081})
+        <extracomment>The name of the StateType ({154e1c19-34c5-4e82-ab4b-b4476b7deb18}) of ThingClass sdm72
 ----------
 The name of the StateType ({4baf1d08-5ffa-49cf-95ef-9527b0c6f081}) of ThingClass sdm630</extracomment>
         <translation>Strom Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="112"/>
-        <source>Current phase A changed</source>
-        <extracomment>The name of the EventType ({4baf1d08-5ffa-49cf-95ef-9527b0c6f081}) of ThingClass sdm630</extracomment>
-        <translation>Strom Phase A geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="115"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="118"/>
+        <location filename="../plugininfo.h" line="87"/>
+        <location filename="../plugininfo.h" line="90"/>
         <source>Current phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPhaseB, ID: {99e47d06-0a6a-4bfd-b164-61ecb6ba2818})
+        <extracomment>The name of the StateType ({210c5ab5-09ab-48e5-89aa-d932aae5215f}) of ThingClass sdm72
 ----------
 The name of the StateType ({99e47d06-0a6a-4bfd-b164-61ecb6ba2818}) of ThingClass sdm630</extracomment>
         <translation>Strom Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="121"/>
-        <source>Current phase B changed</source>
-        <extracomment>The name of the EventType ({99e47d06-0a6a-4bfd-b164-61ecb6ba2818}) of ThingClass sdm630</extracomment>
-        <translation>Strom Phase B geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="124"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="127"/>
+        <location filename="../plugininfo.h" line="93"/>
+        <location filename="../plugininfo.h" line="96"/>
         <source>Current phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPhaseC, ID: {4a092a66-352d-4d60-90ab-6ac5f58b92fe})
+        <extracomment>The name of the StateType ({abcfd3ee-6065-421d-bcfc-8c5087aacb46}) of ThingClass sdm72
 ----------
 The name of the StateType ({4a092a66-352d-4d60-90ab-6ac5f58b92fe}) of ThingClass sdm630</extracomment>
         <translation>Strom Phase C</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="130"/>
-        <source>Current phase C changed</source>
-        <extracomment>The name of the EventType ({4a092a66-352d-4d60-90ab-6ac5f58b92fe}) of ThingClass sdm630</extracomment>
-        <translation>Strom Phase C geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="133"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="136"/>
+        <location filename="../plugininfo.h" line="99"/>
+        <location filename="../plugininfo.h" line="102"/>
         <source>Current power</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPower, ID: {c824e97b-a6d1-4030-9d7a-00af6fb8e1c3})
+        <extracomment>The name of the StateType ({d53b97fd-217a-47b6-a73b-f963ece553b2}) of ThingClass sdm72
 ----------
 The name of the StateType ({c824e97b-a6d1-4030-9d7a-00af6fb8e1c3}) of ThingClass sdm630</extracomment>
         <translation>Aktueller Energieverbrauch</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="139"/>
-        <source>Current power changed</source>
-        <extracomment>The name of the EventType ({c824e97b-a6d1-4030-9d7a-00af6fb8e1c3}) of ThingClass sdm630</extracomment>
-        <translation>Aktueller Energieverbrauch geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="142"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="145"/>
+        <location filename="../plugininfo.h" line="105"/>
+        <location filename="../plugininfo.h" line="108"/>
         <source>Current power phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPowerPhaseA, ID: {3982fb12-b179-40f7-9b27-36adb1cadd37})
+        <extracomment>The name of the StateType ({c0d7071c-22f7-4ba7-8158-b297fd8a0929}) of ThingClass sdm72
 ----------
 The name of the StateType ({3982fb12-b179-40f7-9b27-36adb1cadd37}) of ThingClass sdm630</extracomment>
         <translation>Aktueller Energieverbrauch Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="148"/>
-        <source>Current power phase A changed</source>
-        <extracomment>The name of the EventType ({3982fb12-b179-40f7-9b27-36adb1cadd37}) of ThingClass sdm630</extracomment>
-        <translation>Aktueller Energieverbrauch Phase A geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="151"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="154"/>
+        <location filename="../plugininfo.h" line="111"/>
+        <location filename="../plugininfo.h" line="114"/>
         <source>Current power phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPowerPhaseB, ID: {2a231c58-b095-4037-8394-a730431e70b8})
+        <extracomment>The name of the StateType ({3dd97cae-a03c-4afc-9366-0c135e8c2443}) of ThingClass sdm72
 ----------
 The name of the StateType ({2a231c58-b095-4037-8394-a730431e70b8}) of ThingClass sdm630</extracomment>
         <translation>Aktueller Energieverbrauch Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="157"/>
-        <source>Current power phase B changed</source>
-        <extracomment>The name of the EventType ({2a231c58-b095-4037-8394-a730431e70b8}) of ThingClass sdm630</extracomment>
-        <translation>Aktueller Energieverbrauch Phase B geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="160"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="163"/>
+        <location filename="../plugininfo.h" line="117"/>
+        <location filename="../plugininfo.h" line="120"/>
         <source>Current power phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPowerPhaseC, ID: {ee8c4f0c-2b69-4210-9966-1553a592b06d})
+        <extracomment>The name of the StateType ({e4043c04-2410-41ff-acab-65883b7a8569}) of ThingClass sdm72
 ----------
 The name of the StateType ({ee8c4f0c-2b69-4210-9966-1553a592b06d}) of ThingClass sdm630</extracomment>
         <translation>Aktueller Energieverbrauch Phase C</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="166"/>
-        <source>Current power phase C changed</source>
-        <extracomment>The name of the EventType ({ee8c4f0c-2b69-4210-9966-1553a592b06d}) of ThingClass sdm630</extracomment>
-        <translation>Aktueller Energieverbrauch Phase C geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="169"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="172"/>
+        <location filename="../plugininfo.h" line="123"/>
         <source>Energy consumed phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyConsumedPhaseA, ID: {6ca06c81-fe75-4448-a22f-47c303421440})
-----------
-The name of the StateType ({6ca06c81-fe75-4448-a22f-47c303421440}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({6ca06c81-fe75-4448-a22f-47c303421440}) of ThingClass sdm630</extracomment>
         <translation>Gesamtverbrauch Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="175"/>
-        <source>Energy consumed phase A changed</source>
-        <extracomment>The name of the EventType ({6ca06c81-fe75-4448-a22f-47c303421440}) of ThingClass sdm630</extracomment>
-        <translation>Gesamtverbrauch Phase A geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="178"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="181"/>
+        <location filename="../plugininfo.h" line="126"/>
         <source>Energy consumed phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyConsumedPhaseB, ID: {fa2b879b-2a81-4bc8-9577-98082c4d9330})
-----------
-The name of the StateType ({fa2b879b-2a81-4bc8-9577-98082c4d9330}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({fa2b879b-2a81-4bc8-9577-98082c4d9330}) of ThingClass sdm630</extracomment>
         <translation>Gesamtverbrauch Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="184"/>
-        <source>Energy consumed phase B changed</source>
-        <extracomment>The name of the EventType ({fa2b879b-2a81-4bc8-9577-98082c4d9330}) of ThingClass sdm630</extracomment>
-        <translation>Gesamtverbrauch Phase B geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="187"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="190"/>
+        <location filename="../plugininfo.h" line="129"/>
         <source>Energy consumed phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyConsumedPhaseC, ID: {4c084c9e-7a5d-42d1-96b2-a8a4b4a25713})
-----------
-The name of the StateType ({4c084c9e-7a5d-42d1-96b2-a8a4b4a25713}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({4c084c9e-7a5d-42d1-96b2-a8a4b4a25713}) of ThingClass sdm630</extracomment>
         <translation>Gesamtverbrauch Phase C</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="193"/>
-        <source>Energy consumed phase C changed</source>
-        <extracomment>The name of the EventType ({4c084c9e-7a5d-42d1-96b2-a8a4b4a25713}) of ThingClass sdm630</extracomment>
-        <translation>Gesamtverbrauch Phase C geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="196"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="199"/>
+        <location filename="../plugininfo.h" line="132"/>
         <source>Energy produced phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyProducedPhaseA, ID: {308fa88e-6054-4c79-b12a-be2d0a404ef6})
-----------
-The name of the StateType ({308fa88e-6054-4c79-b12a-be2d0a404ef6}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({308fa88e-6054-4c79-b12a-be2d0a404ef6}) of ThingClass sdm630</extracomment>
         <translation>Erzeugte Energie Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="202"/>
-        <source>Energy produced phase A changed</source>
-        <extracomment>The name of the EventType ({308fa88e-6054-4c79-b12a-be2d0a404ef6}) of ThingClass sdm630</extracomment>
-        <translation>Erzeugte Energie Phase A geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="205"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="208"/>
+        <location filename="../plugininfo.h" line="135"/>
         <source>Energy produced phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyProducedPhaseB, ID: {48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39})
-----------
-The name of the StateType ({48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39}) of ThingClass sdm630</extracomment>
         <translation>Erzeugte Energie Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="211"/>
-        <source>Energy produced phase B changed</source>
-        <extracomment>The name of the EventType ({48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39}) of ThingClass sdm630</extracomment>
-        <translation>Erzeugte Energie Phase B geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="214"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="217"/>
+        <location filename="../plugininfo.h" line="138"/>
         <source>Energy produced phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyProducedPhaseC, ID: {6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff})
-----------
-The name of the StateType ({6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff}) of ThingClass sdm630</extracomment>
         <translation>Erzeugte Energie Phase C</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="220"/>
-        <source>Energy produced phase C changed</source>
-        <extracomment>The name of the EventType ({6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff}) of ThingClass sdm630</extracomment>
-        <translation>Erzeugte Energie Phase C geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="223"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="226"/>
+        <location filename="../plugininfo.h" line="141"/>
+        <location filename="../plugininfo.h" line="144"/>
         <source>Frequency</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: frequency, ID: {ab24f26c-dc15-4ec3-8d76-06a48285440b})
+        <extracomment>The name of the StateType ({724821e6-1975-4a38-907a-a853b10480bd}) of ThingClass sdm72
 ----------
 The name of the StateType ({ab24f26c-dc15-4ec3-8d76-06a48285440b}) of ThingClass sdm630</extracomment>
         <translation>Frequenz</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="229"/>
-        <source>Frequency changed</source>
-        <extracomment>The name of the EventType ({ab24f26c-dc15-4ec3-8d76-06a48285440b}) of ThingClass sdm630</extracomment>
-        <translation>Frequenz geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="232"/>
+        <location filename="../plugininfo.h" line="147"/>
+        <location filename="../plugininfo.h" line="150"/>
         <source>Modbus RTU master</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {d90e9292-d03c-4f2a-957e-5d965018c9c9})</extracomment>
+        <extracomment>The name of the ParamType (ThingClass: sdm72, Type: thing, ID: {6edc9c2b-e939-4c24-ac81-fc3ca17aab3f})
+----------
+The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {d90e9292-d03c-4f2a-957e-5d965018c9c9})</extracomment>
         <translation>Modbus RTU Master</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="235"/>
+        <location filename="../plugininfo.h" line="153"/>
+        <location filename="../plugininfo.h" line="156"/>
         <source>Modbus slave address</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {ac77ea98-b006-486e-a3e8-b30a483f26c1})</extracomment>
+        <extracomment>The name of the ParamType (ThingClass: sdm72, Type: thing, ID: {6ec32145-f77c-4268-ae1d-159f9702fd85})
+----------
+The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {ac77ea98-b006-486e-a3e8-b30a483f26c1})</extracomment>
         <translation>Modbus Adresse</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="238"/>
+        <location filename="../plugininfo.h" line="159"/>
         <source>SDM630</source>
         <extracomment>The name of the ThingClass ({f37597bb-35fe-48f2-9617-343dd54c0903})</extracomment>
         <translation>SDM630</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="241"/>
+        <location filename="../plugininfo.h" line="162"/>
+        <source>SDM72</source>
+        <extracomment>The name of the ThingClass ({ce54ada6-cbe8-406a-9262-c707c4d8c392})</extracomment>
+        <translation>SDM72</translation>
+    </message>
+    <message>
+        <location filename="../plugininfo.h" line="165"/>
+        <location filename="../plugininfo.h" line="168"/>
         <source>Slave address</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, Type: discovery, ID: {6ab43559-53ec-47ba-b8a0-8d3b7f8d90c2})</extracomment>
+        <extracomment>The name of the ParamType (ThingClass: sdm72, Type: discovery, ID: {27219539-443b-43dc-ad8b-11e7cfb862b5})
+----------
+The name of the ParamType (ThingClass: sdm630, Type: discovery, ID: {6ab43559-53ec-47ba-b8a0-8d3b7f8d90c2})</extracomment>
         <translation>Modbus Adresse</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="244"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="247"/>
+        <location filename="../plugininfo.h" line="171"/>
+        <location filename="../plugininfo.h" line="174"/>
         <source>Total energy consumed</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: totalEnergyConsumed, ID: {98d858a8-22e8-4262-b5c7-25bb027942ad})
+        <extracomment>The name of the StateType ({8a9a9212-21aa-4d5a-a528-7781a087f3a2}) of ThingClass sdm72
 ----------
 The name of the StateType ({98d858a8-22e8-4262-b5c7-25bb027942ad}) of ThingClass sdm630</extracomment>
         <translation>Gesamter Energieverbrauch</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="250"/>
-        <source>Total energy consumed changed</source>
-        <extracomment>The name of the EventType ({98d858a8-22e8-4262-b5c7-25bb027942ad}) of ThingClass sdm630</extracomment>
-        <translation>Gesamter Energieverbrauch geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="253"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="256"/>
+        <location filename="../plugininfo.h" line="177"/>
+        <location filename="../plugininfo.h" line="180"/>
         <source>Total energy produced</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: totalEnergyProduced, ID: {e469b3ff-a4c2-42da-af35-ccafaef214af})
+        <extracomment>The name of the StateType ({7b8592ca-2173-459e-85ab-9b4aec4970c6}) of ThingClass sdm72
 ----------
 The name of the StateType ({e469b3ff-a4c2-42da-af35-ccafaef214af}) of ThingClass sdm630</extracomment>
         <translation>Gesamte erzeugte Energie</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="259"/>
-        <source>Total energy produced changed</source>
-        <extracomment>The name of the EventType ({e469b3ff-a4c2-42da-af35-ccafaef214af}) of ThingClass sdm630</extracomment>
-        <translation>Gesamte erzeugte Energie geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="262"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="265"/>
+        <location filename="../plugininfo.h" line="183"/>
+        <location filename="../plugininfo.h" line="186"/>
         <source>Voltage phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: voltagePhaseA, ID: {db018146-0441-4dc0-9834-6d43ebaf8311})
+        <extracomment>The name of the StateType ({15b5e57b-7584-4be0-9053-55bb495435a5}) of ThingClass sdm72
 ----------
 The name of the StateType ({db018146-0441-4dc0-9834-6d43ebaf8311}) of ThingClass sdm630</extracomment>
         <translation>Spannung Phase A</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="268"/>
-        <source>Voltage phase A changed</source>
-        <extracomment>The name of the EventType ({db018146-0441-4dc0-9834-6d43ebaf8311}) of ThingClass sdm630</extracomment>
-        <translation>Spannung Phase A geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="271"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="274"/>
+        <location filename="../plugininfo.h" line="189"/>
+        <location filename="../plugininfo.h" line="192"/>
         <source>Voltage phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: voltagePhaseB, ID: {406f6d02-d5eb-49b3-87da-3247568e6054})
+        <extracomment>The name of the StateType ({998cf8e7-38e9-433a-8ef5-726b45bbfc63}) of ThingClass sdm72
 ----------
 The name of the StateType ({406f6d02-d5eb-49b3-87da-3247568e6054}) of ThingClass sdm630</extracomment>
         <translation>Spannung Phase B</translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="277"/>
-        <source>Voltage phase B changed</source>
-        <extracomment>The name of the EventType ({406f6d02-d5eb-49b3-87da-3247568e6054}) of ThingClass sdm630</extracomment>
-        <translation>Spannung Phase B geändert</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="280"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="283"/>
+        <location filename="../plugininfo.h" line="195"/>
+        <location filename="../plugininfo.h" line="198"/>
         <source>Voltage phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: voltagePhaseC, ID: {ace6294d-deaa-4d9a-af78-d64379bcb229})
+        <extracomment>The name of the StateType ({48164e10-0217-45e2-bf8f-5ec396c43ceb}) of ThingClass sdm72
 ----------
 The name of the StateType ({ace6294d-deaa-4d9a-af78-d64379bcb229}) of ThingClass sdm630</extracomment>
         <translation>Spannung Phase C</translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="286"/>
-        <source>Voltage phase C changed</source>
-        <extracomment>The name of the EventType ({ace6294d-deaa-4d9a-af78-d64379bcb229}) of ThingClass sdm630</extracomment>
-        <translation>Spannung Phase C geändert</translation>
     </message>
 </context>
 </TS>

--- a/bgetech/translations/e373f492-4527-4d5f-aa48-34d38c55b0d6-en_US.ts
+++ b/bgetech/translations/e373f492-4527-4d5f-aa48-34d38c55b0d6-en_US.ts
@@ -1,25 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="en_US">
 <context>
     <name>IntegrationPluginBGETech</name>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="57"/>
+        <location filename="../integrationpluginbgetech.cpp" line="65"/>
         <source>No Modbus RTU interface available. Please set up the Modbus RTU interface first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="63"/>
+        <location filename="../integrationpluginbgetech.cpp" line="72"/>
+        <location filename="../integrationpluginbgetech.cpp" line="94"/>
         <source>The Modbus slave address must be a value between 1 and 254.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="92"/>
+        <location filename="../integrationpluginbgetech.cpp" line="125"/>
+        <location filename="../integrationpluginbgetech.cpp" line="235"/>
         <source>The Modbus address not valid. It must be a value between 1 and 254.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../integrationpluginbgetech.cpp" line="99"/>
+        <location filename="../integrationpluginbgetech.cpp" line="132"/>
+        <location filename="../integrationpluginbgetech.cpp" line="242"/>
         <source>The Modbus RTU interface not available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27,8 +30,8 @@
 <context>
     <name>bgeTech</name>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="91"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="94"/>
+        <location filename="../plugininfo.h" line="69"/>
+        <location filename="../plugininfo.h" line="72"/>
         <source>B+G E-Tech</source>
         <extracomment>The name of the vendor ({215035fe-95e8-43d8-a52e-0a31b787d902})
 ----------
@@ -36,327 +39,204 @@ The name of the plugin bgeTech ({e373f492-4527-4d5f-aa48-34d38c55b0d6})</extraco
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="97"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="100"/>
+        <location filename="../plugininfo.h" line="75"/>
+        <location filename="../plugininfo.h" line="78"/>
         <source>Connected</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: connected, ID: {8050bd0b-1dad-4a7e-b632-c71ead3c9f8b})
+        <extracomment>The name of the StateType ({3b69f8e9-1788-4b71-8bd6-bece89f1d045}) of ThingClass sdm72
 ----------
 The name of the StateType ({8050bd0b-1dad-4a7e-b632-c71ead3c9f8b}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="103"/>
-        <source>Connected changed</source>
-        <extracomment>The name of the EventType ({8050bd0b-1dad-4a7e-b632-c71ead3c9f8b}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="106"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="109"/>
+        <location filename="../plugininfo.h" line="81"/>
+        <location filename="../plugininfo.h" line="84"/>
         <source>Current phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPhaseA, ID: {4baf1d08-5ffa-49cf-95ef-9527b0c6f081})
+        <extracomment>The name of the StateType ({154e1c19-34c5-4e82-ab4b-b4476b7deb18}) of ThingClass sdm72
 ----------
 The name of the StateType ({4baf1d08-5ffa-49cf-95ef-9527b0c6f081}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="112"/>
-        <source>Current phase A changed</source>
-        <extracomment>The name of the EventType ({4baf1d08-5ffa-49cf-95ef-9527b0c6f081}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="115"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="118"/>
+        <location filename="../plugininfo.h" line="87"/>
+        <location filename="../plugininfo.h" line="90"/>
         <source>Current phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPhaseB, ID: {99e47d06-0a6a-4bfd-b164-61ecb6ba2818})
+        <extracomment>The name of the StateType ({210c5ab5-09ab-48e5-89aa-d932aae5215f}) of ThingClass sdm72
 ----------
 The name of the StateType ({99e47d06-0a6a-4bfd-b164-61ecb6ba2818}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="121"/>
-        <source>Current phase B changed</source>
-        <extracomment>The name of the EventType ({99e47d06-0a6a-4bfd-b164-61ecb6ba2818}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="124"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="127"/>
+        <location filename="../plugininfo.h" line="93"/>
+        <location filename="../plugininfo.h" line="96"/>
         <source>Current phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPhaseC, ID: {4a092a66-352d-4d60-90ab-6ac5f58b92fe})
+        <extracomment>The name of the StateType ({abcfd3ee-6065-421d-bcfc-8c5087aacb46}) of ThingClass sdm72
 ----------
 The name of the StateType ({4a092a66-352d-4d60-90ab-6ac5f58b92fe}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="130"/>
-        <source>Current phase C changed</source>
-        <extracomment>The name of the EventType ({4a092a66-352d-4d60-90ab-6ac5f58b92fe}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="133"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="136"/>
+        <location filename="../plugininfo.h" line="99"/>
+        <location filename="../plugininfo.h" line="102"/>
         <source>Current power</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPower, ID: {c824e97b-a6d1-4030-9d7a-00af6fb8e1c3})
+        <extracomment>The name of the StateType ({d53b97fd-217a-47b6-a73b-f963ece553b2}) of ThingClass sdm72
 ----------
 The name of the StateType ({c824e97b-a6d1-4030-9d7a-00af6fb8e1c3}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="139"/>
-        <source>Current power changed</source>
-        <extracomment>The name of the EventType ({c824e97b-a6d1-4030-9d7a-00af6fb8e1c3}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="142"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="145"/>
+        <location filename="../plugininfo.h" line="105"/>
+        <location filename="../plugininfo.h" line="108"/>
         <source>Current power phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPowerPhaseA, ID: {3982fb12-b179-40f7-9b27-36adb1cadd37})
+        <extracomment>The name of the StateType ({c0d7071c-22f7-4ba7-8158-b297fd8a0929}) of ThingClass sdm72
 ----------
 The name of the StateType ({3982fb12-b179-40f7-9b27-36adb1cadd37}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="148"/>
-        <source>Current power phase A changed</source>
-        <extracomment>The name of the EventType ({3982fb12-b179-40f7-9b27-36adb1cadd37}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="151"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="154"/>
+        <location filename="../plugininfo.h" line="111"/>
+        <location filename="../plugininfo.h" line="114"/>
         <source>Current power phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPowerPhaseB, ID: {2a231c58-b095-4037-8394-a730431e70b8})
+        <extracomment>The name of the StateType ({3dd97cae-a03c-4afc-9366-0c135e8c2443}) of ThingClass sdm72
 ----------
 The name of the StateType ({2a231c58-b095-4037-8394-a730431e70b8}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="157"/>
-        <source>Current power phase B changed</source>
-        <extracomment>The name of the EventType ({2a231c58-b095-4037-8394-a730431e70b8}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="160"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="163"/>
+        <location filename="../plugininfo.h" line="117"/>
+        <location filename="../plugininfo.h" line="120"/>
         <source>Current power phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: currentPowerPhaseC, ID: {ee8c4f0c-2b69-4210-9966-1553a592b06d})
+        <extracomment>The name of the StateType ({e4043c04-2410-41ff-acab-65883b7a8569}) of ThingClass sdm72
 ----------
 The name of the StateType ({ee8c4f0c-2b69-4210-9966-1553a592b06d}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="166"/>
-        <source>Current power phase C changed</source>
-        <extracomment>The name of the EventType ({ee8c4f0c-2b69-4210-9966-1553a592b06d}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="169"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="172"/>
+        <location filename="../plugininfo.h" line="123"/>
         <source>Energy consumed phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyConsumedPhaseA, ID: {6ca06c81-fe75-4448-a22f-47c303421440})
-----------
-The name of the StateType ({6ca06c81-fe75-4448-a22f-47c303421440}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({6ca06c81-fe75-4448-a22f-47c303421440}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="175"/>
-        <source>Energy consumed phase A changed</source>
-        <extracomment>The name of the EventType ({6ca06c81-fe75-4448-a22f-47c303421440}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="178"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="181"/>
+        <location filename="../plugininfo.h" line="126"/>
         <source>Energy consumed phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyConsumedPhaseB, ID: {fa2b879b-2a81-4bc8-9577-98082c4d9330})
-----------
-The name of the StateType ({fa2b879b-2a81-4bc8-9577-98082c4d9330}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({fa2b879b-2a81-4bc8-9577-98082c4d9330}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="184"/>
-        <source>Energy consumed phase B changed</source>
-        <extracomment>The name of the EventType ({fa2b879b-2a81-4bc8-9577-98082c4d9330}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="187"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="190"/>
+        <location filename="../plugininfo.h" line="129"/>
         <source>Energy consumed phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyConsumedPhaseC, ID: {4c084c9e-7a5d-42d1-96b2-a8a4b4a25713})
-----------
-The name of the StateType ({4c084c9e-7a5d-42d1-96b2-a8a4b4a25713}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({4c084c9e-7a5d-42d1-96b2-a8a4b4a25713}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="193"/>
-        <source>Energy consumed phase C changed</source>
-        <extracomment>The name of the EventType ({4c084c9e-7a5d-42d1-96b2-a8a4b4a25713}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="196"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="199"/>
+        <location filename="../plugininfo.h" line="132"/>
         <source>Energy produced phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyProducedPhaseA, ID: {308fa88e-6054-4c79-b12a-be2d0a404ef6})
-----------
-The name of the StateType ({308fa88e-6054-4c79-b12a-be2d0a404ef6}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({308fa88e-6054-4c79-b12a-be2d0a404ef6}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="202"/>
-        <source>Energy produced phase A changed</source>
-        <extracomment>The name of the EventType ({308fa88e-6054-4c79-b12a-be2d0a404ef6}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="205"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="208"/>
+        <location filename="../plugininfo.h" line="135"/>
         <source>Energy produced phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyProducedPhaseB, ID: {48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39})
-----------
-The name of the StateType ({48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="211"/>
-        <source>Energy produced phase B changed</source>
-        <extracomment>The name of the EventType ({48ab6e61-dfb4-4f85-b5cc-9d89e53c6b39}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="214"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="217"/>
+        <location filename="../plugininfo.h" line="138"/>
         <source>Energy produced phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: energyProducedPhaseC, ID: {6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff})
-----------
-The name of the StateType ({6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff}) of ThingClass sdm630</extracomment>
+        <extracomment>The name of the StateType ({6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="220"/>
-        <source>Energy produced phase C changed</source>
-        <extracomment>The name of the EventType ({6b3ddf15-3d4b-4dc1-8e5a-84fbf90b49ff}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="223"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="226"/>
+        <location filename="../plugininfo.h" line="141"/>
+        <location filename="../plugininfo.h" line="144"/>
         <source>Frequency</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: frequency, ID: {ab24f26c-dc15-4ec3-8d76-06a48285440b})
+        <extracomment>The name of the StateType ({724821e6-1975-4a38-907a-a853b10480bd}) of ThingClass sdm72
 ----------
 The name of the StateType ({ab24f26c-dc15-4ec3-8d76-06a48285440b}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="229"/>
-        <source>Frequency changed</source>
-        <extracomment>The name of the EventType ({ab24f26c-dc15-4ec3-8d76-06a48285440b}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="232"/>
+        <location filename="../plugininfo.h" line="147"/>
+        <location filename="../plugininfo.h" line="150"/>
         <source>Modbus RTU master</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {d90e9292-d03c-4f2a-957e-5d965018c9c9})</extracomment>
+        <extracomment>The name of the ParamType (ThingClass: sdm72, Type: thing, ID: {6edc9c2b-e939-4c24-ac81-fc3ca17aab3f})
+----------
+The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {d90e9292-d03c-4f2a-957e-5d965018c9c9})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="235"/>
+        <location filename="../plugininfo.h" line="153"/>
+        <location filename="../plugininfo.h" line="156"/>
         <source>Modbus slave address</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {ac77ea98-b006-486e-a3e8-b30a483f26c1})</extracomment>
+        <extracomment>The name of the ParamType (ThingClass: sdm72, Type: thing, ID: {6ec32145-f77c-4268-ae1d-159f9702fd85})
+----------
+The name of the ParamType (ThingClass: sdm630, Type: thing, ID: {ac77ea98-b006-486e-a3e8-b30a483f26c1})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="238"/>
+        <location filename="../plugininfo.h" line="159"/>
         <source>SDM630</source>
         <extracomment>The name of the ThingClass ({f37597bb-35fe-48f2-9617-343dd54c0903})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="241"/>
-        <source>Slave address</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, Type: discovery, ID: {6ab43559-53ec-47ba-b8a0-8d3b7f8d90c2})</extracomment>
+        <location filename="../plugininfo.h" line="162"/>
+        <source>SDM72</source>
+        <extracomment>The name of the ThingClass ({ce54ada6-cbe8-406a-9262-c707c4d8c392})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="244"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="247"/>
+        <location filename="../plugininfo.h" line="165"/>
+        <location filename="../plugininfo.h" line="168"/>
+        <source>Slave address</source>
+        <extracomment>The name of the ParamType (ThingClass: sdm72, Type: discovery, ID: {27219539-443b-43dc-ad8b-11e7cfb862b5})
+----------
+The name of the ParamType (ThingClass: sdm630, Type: discovery, ID: {6ab43559-53ec-47ba-b8a0-8d3b7f8d90c2})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../plugininfo.h" line="171"/>
+        <location filename="../plugininfo.h" line="174"/>
         <source>Total energy consumed</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: totalEnergyConsumed, ID: {98d858a8-22e8-4262-b5c7-25bb027942ad})
+        <extracomment>The name of the StateType ({8a9a9212-21aa-4d5a-a528-7781a087f3a2}) of ThingClass sdm72
 ----------
 The name of the StateType ({98d858a8-22e8-4262-b5c7-25bb027942ad}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="250"/>
-        <source>Total energy consumed changed</source>
-        <extracomment>The name of the EventType ({98d858a8-22e8-4262-b5c7-25bb027942ad}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="253"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="256"/>
+        <location filename="../plugininfo.h" line="177"/>
+        <location filename="../plugininfo.h" line="180"/>
         <source>Total energy produced</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: totalEnergyProduced, ID: {e469b3ff-a4c2-42da-af35-ccafaef214af})
+        <extracomment>The name of the StateType ({7b8592ca-2173-459e-85ab-9b4aec4970c6}) of ThingClass sdm72
 ----------
 The name of the StateType ({e469b3ff-a4c2-42da-af35-ccafaef214af}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="259"/>
-        <source>Total energy produced changed</source>
-        <extracomment>The name of the EventType ({e469b3ff-a4c2-42da-af35-ccafaef214af}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="262"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="265"/>
+        <location filename="../plugininfo.h" line="183"/>
+        <location filename="../plugininfo.h" line="186"/>
         <source>Voltage phase A</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: voltagePhaseA, ID: {db018146-0441-4dc0-9834-6d43ebaf8311})
+        <extracomment>The name of the StateType ({15b5e57b-7584-4be0-9053-55bb495435a5}) of ThingClass sdm72
 ----------
 The name of the StateType ({db018146-0441-4dc0-9834-6d43ebaf8311}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="268"/>
-        <source>Voltage phase A changed</source>
-        <extracomment>The name of the EventType ({db018146-0441-4dc0-9834-6d43ebaf8311}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="271"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="274"/>
+        <location filename="../plugininfo.h" line="189"/>
+        <location filename="../plugininfo.h" line="192"/>
         <source>Voltage phase B</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: voltagePhaseB, ID: {406f6d02-d5eb-49b3-87da-3247568e6054})
+        <extracomment>The name of the StateType ({998cf8e7-38e9-433a-8ef5-726b45bbfc63}) of ThingClass sdm72
 ----------
 The name of the StateType ({406f6d02-d5eb-49b3-87da-3247568e6054}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="277"/>
-        <source>Voltage phase B changed</source>
-        <extracomment>The name of the EventType ({406f6d02-d5eb-49b3-87da-3247568e6054}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="280"/>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="283"/>
+        <location filename="../plugininfo.h" line="195"/>
+        <location filename="../plugininfo.h" line="198"/>
         <source>Voltage phase C</source>
-        <extracomment>The name of the ParamType (ThingClass: sdm630, EventType: voltagePhaseC, ID: {ace6294d-deaa-4d9a-af78-d64379bcb229})
+        <extracomment>The name of the StateType ({48164e10-0217-45e2-bf8f-5ec396c43ceb}) of ThingClass sdm72
 ----------
 The name of the StateType ({ace6294d-deaa-4d9a-af78-d64379bcb229}) of ThingClass sdm630</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../../build/nymea-plugins-modbus-Desktop-Debug/bgetech/plugininfo.h" line="286"/>
-        <source>Voltage phase C changed</source>
-        <extracomment>The name of the EventType ({ace6294d-deaa-4d9a-af78-d64379bcb229}) of ThingClass sdm630</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the plugin's README.md accordingly?

- [x] Did you update translations (`cd builddir && make lupdate`)?

Also changed "checkReachableRegister" on SDM630 from current to voltage. Current can be 0 and thus not trigger "value changed" upon reading the register. Voltage is never 0 if the SDM630 has power and can respond to Modbus calls.  
How this came up: Tested a SDM630 and it showed as "not connected", because current was 0.