### PR TITLE
Amperfied: Fix a crash when the Modbus RTU Master is removed

### DIFF
--- a/amperfied/connecthomediscovery.cpp
+++ b/amperfied/connecthomediscovery.cpp
@@ -85,6 +85,13 @@ void ConnectHomeDiscovery::checkNetworkDevice(const NetworkDeviceInfo &networkDe
                 cleanupConnection(connection);
                 return;
             }
+
+            if (connection->version() < 0x100 || connection->version() > 0x2ff) {
+                qCInfo(dcAmperfied()) << "Skipping invalid/unsupported AMPERFIED version" << connection->version();
+                cleanupConnection(connection);
+                return;
+            }
+
             Result result;
             result.firmwareVersion = connection->version();
             result.networkDeviceInfo = networkDeviceInfo;

--- a/amperfied/integrationpluginamperfied.cpp
+++ b/amperfied/integrationpluginamperfied.cpp
@@ -270,6 +270,11 @@ void IntegrationPluginAmperfied::setupRtuConnection(ThingSetupInfo *info)
 {
     Thing *thing = info->thing();
     ModbusRtuMaster *master = hardwareManager()->modbusRtuResource()->getModbusRtuMaster(thing->paramValue(energyControlThingRtuMasterParamTypeId).toUuid());
+    if (!master) {
+        qCWarning(dcAmperfied()) << "The Modbus Master is not available any more.";
+        info->finish(Thing::ThingErrorHardwareNotAvailable, QT_TR_NOOP("The modbus RTU connection is not available."));
+        return;
+    }
     quint16 slaveId = thing->paramValue(energyControlThingSlaveIdParamTypeId).toUInt();
     AmperfiedModbusRtuConnection *connection = new AmperfiedModbusRtuConnection(master, slaveId, thing);
 

--- a/amperfied/integrationpluginamperfied.cpp
+++ b/amperfied/integrationpluginamperfied.cpp
@@ -44,8 +44,6 @@ IntegrationPluginAmperfied::IntegrationPluginAmperfied()
 
 void IntegrationPluginAmperfied::discoverThings(ThingDiscoveryInfo *info)
 {
-    hardwareManager()->modbusRtuResource();
-
     if (info->thingClassId() == energyControlThingClassId) {
         EnergyControlDiscovery *discovery = new EnergyControlDiscovery(hardwareManager()->modbusRtuResource(), info);
 


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
