### PR TITLE
Schrack: Ignore bogus CP signal state which happens occationally

### DIFF
--- a/schrack/integrationpluginschrack.cpp
+++ b/schrack/integrationpluginschrack.cpp
@@ -154,6 +154,10 @@ void IntegrationPluginSchrack::setupThing(ThingSetupInfo *info)
 
     connect(cionConnection, &CionModbusRtuConnection::cpSignalStateChanged, thing, [=](quint16 cpSignalState){
         qCDebug(dcSchrack()) << "CP Signal state changed:" << (char)cpSignalState;
+        if (cpSignalState < 65 || cpSignalState > 68) {
+            qCWarning(dcSchrack()) << "Ignoring bogus CP signal state value" << cpSignalState;
+            return;
+        }
         thing->setStateValue(cionPluggedInStateTypeId, cpSignalState >= 66);
     });
 


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
