### PR TITLE
UniPi: Removed UniPi debian package dependency to wiringpi

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -233,7 +233,6 @@ Multi-Arch: same
 Section: libs
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         wiringpi,
 Replaces: nymea-plugin-unipi
 Description: nymea integration plugin for UniPi devices
  This package contains the nymea integration plugin for UniPi devices.


### PR DESCRIPTION
nymea-plugins-modbus pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
