### PR TITLE
SMA: Improve debug logging when offline

### DIFF
--- a/sma/speedwire/speedwireinterface.cpp
+++ b/sma/speedwire/speedwireinterface.cpp
@@ -147,10 +147,21 @@ void SpeedwireInterface::reconfigureMulticastGroup()
     qCDebug(dcSma()) << "Reconfigure multicast interfaces";
     if (m_multicast->joinMulticastGroup(Speedwire::multicastAddress())) {
         qCDebug(dcSma()) << "SpeedwireInterface: Joined successfully multicast group" << Speedwire::multicastAddress().toString();
+        m_multicastWarningPrintCount = 0;
     } else {
-        qCWarning(dcSma()) << "SpeedwireInterface: Failed to join multicast group" << Speedwire::multicastAddress().toString() << m_multicast->errorString() << "Retrying in 5 seconds...";
         // FIXME: It would probably be better to monitor the network interfaces and re-join if necessary
+        uint mod = m_multicastWarningPrintCount % 120;
+
+        if (m_multicastWarningPrintCount < 12) {
+            qCWarning(dcSma()) << "SpeedwireInterface: Failed to join multicast group" << Speedwire::multicastAddress().toString() << m_multicast->errorString() << "Retrying in 5 seconds...";
+        }
+
+        if (m_multicastWarningPrintCount >= 12 && mod == 0) {
+            qCWarning(dcSma()) << "SpeedwireInterface: Failed to join multicast group" << Speedwire::multicastAddress().toString() << m_multicast->errorString() << "Retrying in 10 minutes...";
+        }
+
         QTimer::singleShot(5000, this, &SpeedwireInterface::reconfigureMulticastGroup);
+        m_multicastWarningPrintCount++;
     }
 
     //    foreach (const QNetworkInterface &interface, QNetworkInterface::allInterfaces()) {

--- a/sma/speedwire/speedwireinterface.h
+++ b/sma/speedwire/speedwireinterface.h
@@ -70,6 +70,7 @@ private:
     quint32 m_sourceSerialNumber = 0;
     bool m_available = false;
     QTimer m_multicastReconfigureationTimer;
+    uint m_multicastWarningPrintCount = 0;
 };
 
 


### PR DESCRIPTION
When SMA integration can't join the multicast group it begins spaming the log each 5s. With this commit it logs the joining problem each 5s for the first minute, after that each 10min.

nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
