### PR TITLE
libnymea-sunspec: Fix conversion from float to quint16 in SunSpecDataPoint::convertFromFloatWithSSF

### DIFF
--- a/libnymea-sunspec/sunspecdatapoint.cpp
+++ b/libnymea-sunspec/sunspecdatapoint.cpp
@@ -714,7 +714,7 @@ QVector<quint16> SunSpecDataPoint::convertFromFloatWithSSF(float value, qint16 s
         break;
     }
     case Int16: {
-        quint16 rawValue = static_cast<quint16>(value * pow(10, -1 * scaleFactor));
+        quint16 rawValue = static_cast<qint16>(value * pow(10, -1 * scaleFactor));
         rawData << rawValue;
         break;
     }


### PR DESCRIPTION
Fix conversion from float to quint16 in SunSpecDataPoint::convertFromFloatWithSSF

Calling this function with a negative value and DataType::Int16 always gives a 0 result on ARM. Need to convert to qint16 first to avoid undefined behavior, cf. [https://embeddeduse.com/2013/08/25/casting-a-negative-float-to-an-unsigned-int/](https://embeddeduse.com/2013/08/25/casting-a-negative-float-to-an-unsigned-int/)

nymea-plugins-modbus pull request checklist:

- [x] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [x] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
