### PR TITLE
libnymea-sunpsec-dev: Fix model header installation path 

### DIFF
--- a/libnymea-sunspec/libnymea-sunspec.pro
+++ b/libnymea-sunspec/libnymea-sunspec.pro
@@ -45,8 +45,13 @@ target.path = $$[QT_INSTALL_LIBS]
 INSTALLS += target
 
 # install header file with relative subdirectory
+# Note: generated model headers (models/models.pri) use $$PWD/-prefixed absolute paths,
+# while root headers are relative to this .pro file. Normalize both via relative_path()
+# before taking dirname(), otherwise dirname() on an absolute header path leaks the
+# build-time source directory into the install path.
 for (header, HEADERS) {
-    path = $$[QT_INSTALL_PREFIX]/include/nymea-sunspec/$${dirname(header)}
+    relHeader = $$relative_path($$absolute_path($$header, $$PWD), $$PWD)
+    path = $$[QT_INSTALL_PREFIX]/include/nymea-sunspec/$${dirname(relHeader)}
     eval(headers_$${path}.files += $${header})
     eval(headers_$${path}.path = $${path})
     eval(INSTALLS *= headers_$${path})


### PR DESCRIPTION
Fixes issue #248

nymea-plugins-modbus pull request checklist:

- [ ] Make sure the pull request's title is of format "Plugin name: Add support for xyz" or "New plugin: Plugin name"

- [ ] Did you test the changes on hardware, if not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update the plugin's README.md accordingly?

- [ ] Did you update translations (`cd builddir && make lupdate`)?
